### PR TITLE
Annotate class with obj-c name to be able to check its existence using `NSClassFromString`

### DIFF
--- a/ios/Classes/PlayerPlugin.swift
+++ b/ios/Classes/PlayerPlugin.swift
@@ -1,6 +1,7 @@
 import Flutter
 import UIKit
 
+@objc(PlayerPlugin)
 public class PlayerPlugin: NSObject, FlutterPlugin {
     weak var registrar: FlutterPluginRegistrar?
 


### PR DESCRIPTION
In order to be able to detect the integration environment from within the Bitmovin iOS Player SDK, we need to check if the class `PlayerPlugin` exists at runtime. To be able to do so using `NSClassFromString`, we need to annotate it with its obj-c name.