### PR TITLE
Align nullness with other SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- APIs that returned placeholder values on invalid state now return null:
+  - `player.availableSubtitles` now returns `null` when there is no active source
+  - `player.subtitle` now returns `null` when there is no active subtitle track
 
 ## [0.1.0] - 2023-09-28
 ### Added

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayer.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayer.kt
@@ -75,7 +75,7 @@ class FlutterPlayer(
     private fun Player.onMethodCall(
         method: String,
         arg: JPlayerMethodArg,
-    ): Any =
+    ): Any? =
         when (method) {
             Methods.LOAD_WITH_SOURCE_CONFIG -> load(arg.asSourceConfig)
             Methods.LOAD_WITH_SOURCE -> load(arg.asSource.sourceConfig)
@@ -92,11 +92,11 @@ class FlutterPlayer(
             Methods.IS_LIVE -> isLive
             Methods.IS_PLAYING -> isPlaying
             Methods.SEND_CUSTOM_DATA_EVENT ->
-                this.analytics?.sendCustomDataEvent(arg.asCustomData.toNative())
-                    ?: Unit
+                analytics?.sendCustomDataEvent(arg.asCustomData.toNative())
             Methods.DESTROY -> destroyPlayer()
-            Methods.AVAILABLE_SUBTITLES -> availableSubtitles.map { JSubtitleTrack(it).toJsonString() }
-            Methods.GET_SUBTITLE -> subtitle?.let { JSubtitleTrack(it).toJsonString() } ?: Unit
+            Methods.AVAILABLE_SUBTITLES ->
+                availableSubtitles.map { JSubtitleTrack(it).toJsonString() }
+            Methods.GET_SUBTITLE -> subtitle?.let { JSubtitleTrack(it).toJsonString() }
             Methods.SET_SUBTITLE -> setSubtitle(arg.asOptionalString)
             Methods.REMOVE_SUBTITLE -> removeSubtitle(arg.asString)
             else -> throw NotImplementedError()
@@ -111,7 +111,7 @@ class FlutterPlayer(
     private fun onMethodCall(
         method: String,
         arguments: JMethodArgs,
-    ): Any {
+    ): Any? {
         return player.onMethodCall(method, arguments.asPlayerMethodArgs)
     }
 

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/json/JsonMethodHandler.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/json/JsonMethodHandler.kt
@@ -4,7 +4,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 /** set Result from returned object or set an error if an exception is thrown. */
-internal class JsonMethodHandler(private val handler: (String, JMethodArgs) -> Any) :
+internal class JsonMethodHandler(private val handler: (String, JMethodArgs) -> Any?) :
     MethodChannel.MethodCallHandler {
     override fun onMethodCall(
         call: MethodCall,

--- a/example/integration_test/subtitle_test.dart
+++ b/example/integration_test/subtitle_test.dart
@@ -21,11 +21,11 @@ void main() {
     group('when selecting a subtitle', () {
       testWidgets('subtitle is selected', (_) async {
         await startPlayerTest(() async {
-          var subtitleToSelect = '';
+          String? subtitleToSelect;
           await loadSourceConfig(Sources.sintel);
           await callPlayer((player) async {
             final subtitles = await player.availableSubtitles;
-            subtitleToSelect = subtitles.last.id;
+            subtitleToSelect = subtitles?.last.id;
           });
 
           final subtitleChanged = await callPlayerAndExpectEvent(

--- a/lib/src/api/player/player_api.dart
+++ b/lib/src/api/player/player_api.dart
@@ -67,10 +67,12 @@ abstract class PlayerApi {
 
   /// A list of all available [SubtitleTrack]s of the active [Source],
   /// including "off" subtitle track.
-  Future<List<SubtitleTrack>> get availableSubtitles;
+  /// `null` if there are no active [Source].
+  Future<List<SubtitleTrack>?> get availableSubtitles;
 
   /// The currently selected [SubtitleTrack].
-  Future<SubtitleTrack> get subtitle;
+  /// `null` if there is no currently selected [SubtitleTrack].
+  Future<SubtitleTrack?> get subtitle;
 
   /// Sets the currently selected [SubtitleTrack] based on the provided [id].
   /// Using `null` as [id] disables subtitles. A list of currently available

--- a/lib/src/player.dart
+++ b/lib/src/player.dart
@@ -168,7 +168,7 @@ class Player with PlayerEventHandler implements PlayerApi {
 
   // Can be used to call methods on the platform side that return a list of
   // complex objects that are not natively supported by the method channel.
-  Future<List<T>> _invokeListObjectsMethod<T>(
+  Future<List<T>?> _invokeListObjectsMethod<T>(
     String methodName,
     T Function(Map<String, dynamic>) fromJson, [
     dynamic data,
@@ -184,7 +184,7 @@ class Player with PlayerEventHandler implements PlayerApi {
     );
 
     if (jsonStringList == null) {
-      return [];
+      return null;
     }
 
     return jsonStringList.map((String jsonString) {
@@ -258,7 +258,7 @@ class Player with PlayerEventHandler implements PlayerApi {
   Future<bool> get isPlaying async => _invokeMethod<bool>(Methods.isPlaying);
 
   @override
-  Future<List<SubtitleTrack>> get availableSubtitles async =>
+  Future<List<SubtitleTrack>?> get availableSubtitles async =>
       _invokeListObjectsMethod<SubtitleTrack>(
         Methods.availableSubtitles,
         SubtitleTrack.fromJson,
@@ -273,12 +273,11 @@ class Player with PlayerEventHandler implements PlayerApi {
       _invokeMethod<void>(Methods.setSubtitle, id);
 
   @override
-  Future<SubtitleTrack> get subtitle async =>
-      await _invokeObjectMethod<SubtitleTrack>(
+  Future<SubtitleTrack?> get subtitle async =>
+      _invokeObjectMethod<SubtitleTrack>(
         Methods.getSubtitle,
         SubtitleTrack.fromJson,
-      ) ??
-      SubtitleTrack.off();
+      );
 
   /// Disposes the player instance.
   Future<void> dispose() async => _invokeMethod<void>(Methods.destroy);


### PR DESCRIPTION
## Problem (PFL-69)
Methods that return nullable types on our native SDK were returning
placeholder values. This was not aligned with our other mobile
SDKs.

## Changes
Return null instead. This also allows simplifying the glue layer.

## Checklist
- [x] 🗒 `CHANGELOG` entry if applicable