### PR TITLE
Put state in Future instead of using Future<isInit>

### DIFF
--- a/lib/src/channel_manager.dart
+++ b/lib/src/channel_manager.dart
@@ -22,7 +22,14 @@ class ChannelManager {
     return target;
   }
 
-  static EventChannel registerEventChannel({required String name}) {
-    return EventChannel(name);
+  static EventChannel registerEventChannel({
+    required String name,
+    void Function(dynamic event)? onEvent,
+    }) {
+    final target = EventChannel(name);
+    if (onEvent != null) {
+      target.receiveBroadcastStream().listen(onEvent);
+    }
+    return target;
   }
 }


### PR DESCRIPTION
The native player was previously initialized and the communication channels set in a separate async context, with a `Future<bool>` guarding when this was done. This is very similar to how it would be done in C with a condition variable.

The safer, and more common in Dart, way is to embed the async result in the future itself. The channels can be safely accessed by `await`ing on the new `Future<NativePlayerHandle>`.

This PR depends on: https://github.com/bitmovin/bitmovin-player-flutter/pull/63