### PR TITLE
Fix material version to 2

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,6 +39,9 @@ class _MyAppState extends State<MyApp> {
       home: const Scaffold(
         body: Home(),
       ),
+      theme: ThemeData(
+        useMaterial3: false,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Description
### Problem
Flutter `3.16.0` contains a breaking change where they changed the default value from `useMaterial3` from `false` to `true` ([ref](https://docs.flutter.dev/release/breaking-changes/material-3-default)).

In case someone needs to use Flutter 3.16.0 (e.g. when using Xcode 15), the example App would look different than expected.

### Changes
This PR fixes sets the `useMaterial3` to `false` to ensure the expected App look and feel even when using Flutter `3.16.0`