### PR TITLE
[iOS] Add `isBackgroundPlaybackEnabled` to `PlaybackConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `isBackgroundPlaybackEnabled` to `PlaybackConfig`. For now this is only supported on iOS.
+
 ## [0.2.0] - 2023-11-06
 ### Added
 - Google Cast Support for Android and iOS
@@ -13,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.1.0] - 2023-09-28
 ### Added
 - Support for DASH (only Android), HLS and progressive playback
-- Support for playing back live streams 
+- Support for playing back live streams
 - DRM support for Widevine on Android and FairPlay on iOS
 - Bitmovin Web UI support, including customizable CSS and JS files
 - Bitmovin Analytics support

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,3 +1,4 @@
+import AVKit
 import Flutter
 import UIKit
 
@@ -8,6 +9,13 @@ internal class AppDelegate: FlutterAppDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // configure for background audio
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback)
+        } catch {
+            print("Setting category to AVAudioSessionCategoryPlayback failed.")
+        }
+
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -58,5 +58,9 @@
 	</array>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Required by Google Cast</string>
+  <key>UIBackgroundModes</key>
+  <array>
+    <string>audio</string>
+  </array>
 </dict>
 </plist>

--- a/example/lib/pages/basic_playback.dart
+++ b/example/lib/pages/basic_playback.dart
@@ -25,6 +25,7 @@ class _BasicPlaybackState extends State<BasicPlayback> {
       key: Env.bitmovinPlayerLicenseKey,
       playbackConfig: PlaybackConfig(
         isAutoplayEnabled: true,
+        isBackgroundPlaybackEnabled: true,
       ),
       remoteControlConfig: RemoteControlConfig(isCastEnabled: false),
     ),

--- a/lib/src/api/player/playback_config.dart
+++ b/lib/src/api/player/playback_config.dart
@@ -11,6 +11,7 @@ class PlaybackConfig extends Equatable {
     this.isAutoplayEnabled = false,
     this.isMuted = false,
     this.isTimeShiftEnabled = true,
+    this.isBackgroundPlaybackEnabled = false,
     this.videoCodecPriority,
     this.audioCodecPriority,
     this.isTunneledPlaybackEnabled = false,
@@ -37,6 +38,18 @@ class PlaybackConfig extends Equatable {
   /// Default value is `true`.
   @JsonKey(name: 'isTimeShiftEnabled')
   final bool isTimeShiftEnabled;
+
+  /// Specifies if background playback is enabled or not.
+  /// Default is `false`.
+  ///
+  /// When set to `true`, playback is not automatically paused
+  /// anymore when the app moves to the background.
+  /// When set to `true`, also make sure to properly configure your app to allow
+  /// background playback.
+  ///
+  /// This is only supported on iOS.
+  @JsonKey(name: 'isBackgroundPlaybackEnabled')
+  final bool isBackgroundPlaybackEnabled;
 
   /// The video codec priority where the index has the highest priority.
   /// For a single [SourceConfig] this can be overwritten using
@@ -96,6 +109,7 @@ class PlaybackConfig extends Equatable {
         isAutoplayEnabled,
         isMuted,
         isTimeShiftEnabled,
+        isBackgroundPlaybackEnabled,
         videoCodecPriority,
         videoFilter,
         audioCodecPriority,

--- a/lib/src/api/player/playback_config.g.dart
+++ b/lib/src/api/player/playback_config.g.dart
@@ -11,6 +11,8 @@ PlaybackConfig _$PlaybackConfigFromJson(Map<String, dynamic> json) =>
       isAutoplayEnabled: json['isAutoplayEnabled'] as bool? ?? false,
       isMuted: json['isMuted'] as bool? ?? false,
       isTimeShiftEnabled: json['isTimeShiftEnabled'] as bool? ?? true,
+      isBackgroundPlaybackEnabled:
+          json['isBackgroundPlaybackEnabled'] as bool? ?? false,
       videoCodecPriority: (json['videoCodecPriority'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
@@ -34,6 +36,7 @@ Map<String, dynamic> _$PlaybackConfigToJson(PlaybackConfig instance) =>
       'isAutoplayEnabled': instance.isAutoplayEnabled,
       'isMuted': instance.isMuted,
       'isTimeShiftEnabled': instance.isTimeShiftEnabled,
+      'isBackgroundPlaybackEnabled': instance.isBackgroundPlaybackEnabled,
       'videoCodecPriority': instance.videoCodecPriority,
       'audioCodecPriority': instance.audioCodecPriority,
       'isTunneledPlaybackEnabled': instance.isTunneledPlaybackEnabled,


### PR DESCRIPTION
## Description
### Changes
This PR adds the possibility of configuring background playback. For now, this is only supported on iOS. Android will follow at a later point. 

To enable background playback, set `PlaybackConfig.isBackgroundPlaybackEnabled` to `true` and configure the App accordingly.