### PR TITLE
Add flutter like background playback example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - `isBackgroundPlaybackEnabled` to `PlaybackConfig`. For now this is only supported on iOS.
+- `BackgroundPlayback` example to the example Application
 
 ## [0.2.0] - 2023-11-06
 ### Added

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - audio_session (0.0.1):
+    - Flutter
   - bitmovin_player (0.2.0):
     - BitmovinPlayer
     - Flutter
@@ -21,6 +23,7 @@ PODS:
   - Protobuf (3.24.3)
 
 DEPENDENCIES:
+  - audio_session (from `.symlinks/plugins/audio_session/ios`)
   - bitmovin_player (from `.symlinks/plugins/bitmovin_player/ios`)
   - BitmovinPlayer (= 3.44.0)
   - Flutter (from `Flutter`)
@@ -37,6 +40,8 @@ SPEC REPOS:
     - Protobuf
 
 EXTERNAL SOURCES:
+  audio_session:
+    :path: ".symlinks/plugins/audio_session/ios"
   bitmovin_player:
     :path: ".symlinks/plugins/bitmovin_player/ios"
   Flutter:
@@ -45,6 +50,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
+  audio_session: 4f3e461722055d21515cf3261b64c973c062f345
   bitmovin_player: 53d71fc6050f3ca441a64a736aec39d5737269c7
   BitmovinAnalyticsCollector: 6aa2e995e325d95d1145bcad3d733d2f8c301c00
   BitmovinPlayer: 2e5b0234c4a49a7c95eb3232d18e3e803013e5c6
@@ -56,4 +62,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: e8313ee3446cb7a867855d589a741918797df0b4
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -9,13 +9,6 @@ internal class AppDelegate: FlutterAppDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // configure for background audio
-        do {
-            try AVAudioSession.sharedInstance().setCategory(.playback)
-        } catch {
-            print("Setting category to AVAudioSessionCategoryPlayback failed.")
-        }
-
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:bitmovin_player_example/pages/analytics.dart';
 import 'package:bitmovin_player_example/pages/audio_only.dart';
+import 'package:bitmovin_player_example/pages/background_playback.dart';
 import 'package:bitmovin_player_example/pages/basic_playback.dart';
 import 'package:bitmovin_player_example/pages/casting.dart';
 import 'package:bitmovin_player_example/pages/custom_html_ui.dart';
@@ -35,6 +36,7 @@ class _MyAppState extends State<MyApp> {
         CustomHtmlUi.routeName: (_) => const CustomHtmlUi(),
         FullscreenHandling.routeName: (_) => const FullscreenHandling(),
         Casting.routeName: (_) => const Casting(),
+        BackgroundPlayback.routeName: (_) => const BackgroundPlayback(),
       },
       home: const Scaffold(
         body: Home(),

--- a/example/lib/pages/background_playback.dart
+++ b/example/lib/pages/background_playback.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:audio_session/audio_session.dart';
+import 'package:bitmovin_player/bitmovin_player.dart';
+import 'package:bitmovin_player_example/controls.dart';
+import 'package:bitmovin_player_example/env/env.dart';
+import 'package:flutter/material.dart';
+
+/// This example showcases how to achieve background playback with the
+/// Bitmovin Player using the `audio_session` package.
+/// https://pub.dev/packages/audio_session
+
+class BackgroundPlayback extends StatefulWidget {
+  const BackgroundPlayback({super.key});
+  static String routeName = 'BackgroundPlayback';
+
+  @override
+  State<BackgroundPlayback> createState() => _BackgroundPlaybackState();
+}
+
+class _BackgroundPlaybackState extends State<BackgroundPlayback> {
+  final _sourceConfig = SourceConfig(
+    url: Platform.isAndroid
+        ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd'
+        : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    type: Platform.isAndroid ? SourceType.dash : SourceType.hls,
+  );
+  final _player = Player(
+    config: const PlayerConfig(
+      key: Env.bitmovinPlayerLicenseKey,
+      playbackConfig: PlaybackConfig(
+        isAutoplayEnabled: true,
+        isBackgroundPlaybackEnabled: true,
+      ),
+      remoteControlConfig: RemoteControlConfig(isCastEnabled: false),
+    ),
+  );
+
+  @override
+  void initState() {
+    setupAudioSession();
+
+    _player.loadSourceConfig(_sourceConfig);
+    super.initState();
+  }
+
+  Future<void> setupAudioSession() async {
+    final session = await AudioSession.instance;
+    await session.configure(const AudioSessionConfiguration.music());
+  }
+
+  @override
+  void dispose() {
+    _player.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Background Playback'),
+      ),
+      body: Column(
+        children: [
+          SizedBox.fromSize(
+            size: const Size.fromHeight(226),
+            child: PlayerView(
+              player: _player,
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(top: 5),
+            child: Controls(
+              onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onPlayPressed: _player.play,
+              onPausePressed: _player.pause,
+              onMutePressed: _player.mute,
+              onUnmutePressed: _player.unmute,
+              onSkipForwardPressed: () async =>
+                  _player.seek(await _player.currentTime + 10),
+              onSkipBackwardPressed: () async =>
+                  _player.seek(await _player.currentTime - 10),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/basic_playback.dart
+++ b/example/lib/pages/basic_playback.dart
@@ -25,7 +25,6 @@ class _BasicPlaybackState extends State<BasicPlayback> {
       key: Env.bitmovinPlayerLicenseKey,
       playbackConfig: PlaybackConfig(
         isAutoplayEnabled: true,
-        isBackgroundPlaybackEnabled: true,
       ),
       remoteControlConfig: RemoteControlConfig(isCastEnabled: false),
     ),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -1,5 +1,6 @@
 import 'package:bitmovin_player_example/pages/analytics.dart';
 import 'package:bitmovin_player_example/pages/audio_only.dart';
+import 'package:bitmovin_player_example/pages/background_playback.dart';
 import 'package:bitmovin_player_example/pages/basic_playback.dart';
 import 'package:bitmovin_player_example/pages/casting.dart';
 import 'package:bitmovin_player_example/pages/custom_html_ui.dart';
@@ -71,6 +72,12 @@ class Home extends StatelessWidget {
                 Navigator.of(context).pushNamed(Casting.routeName);
               },
               child: const Text('Casting'),
+            ),
+            OutlinedButton(
+              onPressed: () {
+                Navigator.of(context).pushNamed(BackgroundPlayback.routeName);
+              },
+              child: const Text('Background Playback'),
             ),
           ],
         ),

--- a/example/lib/pages/home.dart
+++ b/example/lib/pages/home.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:bitmovin_player_example/pages/analytics.dart';
 import 'package:bitmovin_player_example/pages/audio_only.dart';
 import 'package:bitmovin_player_example/pages/background_playback.dart';
@@ -73,11 +75,14 @@ class Home extends StatelessWidget {
               },
               child: const Text('Casting'),
             ),
-            OutlinedButton(
-              onPressed: () {
-                Navigator.of(context).pushNamed(BackgroundPlayback.routeName);
-              },
-              child: const Text('Background Playback'),
+            Visibility(
+              visible: Platform.isIOS,
+              child: OutlinedButton(
+                onPressed: () {
+                  Navigator.of(context).pushNamed(BackgroundPlayback.routeName);
+                },
+                child: const Text('Background Playback'),
+              ),
             ),
           ],
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  audio_session:
+    dependency: "direct main"
+    description:
+      name: audio_session
+      sha256: "6fdf255ed3af86535c96452c33ecff1245990bb25a605bfb1958661ccc3d467f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.18"
   bitmovin_player:
     dependency: "direct main"
     description:
@@ -76,10 +84,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -175,6 +183,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -261,10 +274,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   package_config:
     dependency: transitive
     description:
@@ -285,10 +298,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   player_testing:
     dependency: "direct dev"
     description:
@@ -320,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -345,18 +366,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -385,10 +406,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -425,10 +446,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.1"
+    version: "11.10.0"
   watcher:
     dependency: transitive
     description:
@@ -441,10 +462,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   webdriver:
     dependency: transitive
     description:
@@ -462,5 +483,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
+  flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.19.1 <4.0.0'
 
 dependencies:
+  audio_session: ^0.1.18
   bitmovin_player:
     path: ../
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
## Description
### Changes
In #71 we introduced support for background playback on iOS. We did that by explicitly calling `AVAudioSession` inside of the `AppDelegate.swift`. However, this was not really flutter like.

This PR adds a new sample showcasing how this can be achieved per page from flutter without the need of touching the `AppDelegate.swift`