### PR TITLE
Showcase ambient mode / screen timeout handling

### DIFF
--- a/example/android/app/src/main/kotlin/com/bitmovin/player/flutter/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/bitmovin/player/flutter/example/MainActivity.kt
@@ -2,7 +2,6 @@ package com.bitmovin.player.flutter.example
 
 import android.os.Bundle
 import android.util.Log
-import android.view.WindowManager
 import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import com.google.android.gms.cast.framework.CastContext
 import io.flutter.embedding.android.FlutterFragmentActivity

--- a/example/android/app/src/main/kotlin/com/bitmovin/player/flutter/example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/bitmovin/player/flutter/example/MainActivity.kt
@@ -2,6 +2,8 @@ package com.bitmovin.player.flutter.example
 
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
+import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import com.google.android.gms.cast.framework.CastContext
 import io.flutter.embedding.android.FlutterFragmentActivity
 
@@ -17,5 +19,10 @@ class MainActivity : FlutterFragmentActivity() {
         } catch (e: Exception) {
             Log.w("MainActivity", "Could not initialize cast context", e)
         }
+
+        // Prevent going into ambient mode on Android TV devices / screen timeout on mobile devices during playback.
+        // If your app uses multiple activities make sure to add this flag to the activity that hosts the player.
+        // Reference: https://developer.android.com/training/scheduling/wakelock#screen
+        window.addFlags(FLAG_KEEP_SCREEN_ON)
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Default samples go into ambient mode / screen timeout due to screen inactivity. Since the handling should be implemented on the app to app basis, this PR just adds an example and reference on how this can be handled.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Add `getWindow().addFlags(FLAG_KEEP_SCREEN_ON);` to `MainActivity.java`

## Checklist
- [x] 🗒 `CHANGELOG` entry - No changelog as only example code was updated
