### PR TITLE
Add missing PlayerView lifecycle handling (PiP #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Android: Playback doesn't pause when app goes to background
 
 ## [0.4.0] - 2023-12-12
 ### Added

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -1,6 +1,8 @@
 package com.bitmovin.player.flutter
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -35,8 +37,11 @@ class FlutterPlayerView(
             messenger,
         )
 
-    private val activity = context.requireActivity()
     private val playerView: PlayerView = PlayerView(context, player = null)
+
+    private val activity =
+        context.getActivity()
+            ?: error("Trying to create an instance of ${this::class.simpleName} while not attached to an Activity")
 
     private val activityLifecycle =
         (activity as? LifecycleOwner)
@@ -105,4 +110,11 @@ class FlutterPlayerView(
     override fun onCancel(arguments: Any?) {
         sink = null
     }
+
+    private fun Context.getActivity(): Activity? =
+        when (this) {
+            is Activity -> this
+            is ContextWrapper -> baseContext.getActivity()
+            else -> null
+        }
 }

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.bitmovin.player.PlayerView
 import com.bitmovin.player.flutter.json.JPlayerViewCreateArgs
-import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
@@ -41,12 +39,9 @@ class FlutterPlayerView(
     private val playerView: PlayerView = PlayerView(context, player = null)
 
     private val activityLifecycle =
-        activity.let { it as? FlutterActivity ?: it as? FlutterFragmentActivity }
+        (activity as? LifecycleOwner)
             ?.lifecycle
-            ?: error(
-                "Trying to create an instance of ${this::class.simpleName}" +
-                    " while not attached to a FlutterActivity or FlutterFragmentActivity",
-            )
+            ?: error("Trying to create an instance of ${this::class.simpleName} while not attached to a LifecycleOwner")
 
     private val activityLifecycleObserver =
         object : DefaultLifecycleObserver {

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -25,8 +25,6 @@ class FlutterPlayerView(
     id: Int,
     args: Any?,
 ) : MethodChannel.MethodCallHandler, EventChannel.StreamHandler, PlatformView, EventListener() {
-    private val activity = context.requireActivity()
-    private val playerView: PlayerView = PlayerView(context, player = null)
     private val methodChannel: MethodChannel =
         MethodChannel(
             messenger,
@@ -38,6 +36,9 @@ class FlutterPlayerView(
             this@FlutterPlayerView,
             messenger,
         )
+
+    private val activity = context.requireActivity()
+    private val playerView: PlayerView = PlayerView(context, player = null)
 
     private val activityLifecycle =
         activity.let { it as? FlutterActivity ?: it as? FlutterFragmentActivity }

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -92,9 +92,7 @@ class FlutterPlayerView(
     ) = when (call.method) {
         Methods.ENTER_FULLSCREEN -> playerView.enterFullscreen()
         Methods.EXIT_FULLSCREEN -> playerView.exitFullscreen()
-        Methods.DESTROY_PLAYER_VIEW -> { // no-op
-        }
-
+        Methods.DESTROY_PLAYER_VIEW -> Unit // no-op
         else -> throw NotImplementedError()
     }
 

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -49,21 +49,13 @@ class FlutterPlayerView(
 
     private val activityLifecycleObserver =
         object : DefaultLifecycleObserver {
-            override fun onStart(owner: LifecycleOwner) {
-                playerView.onStart()
-            }
+            override fun onStart(owner: LifecycleOwner) = playerView.onStart()
 
-            override fun onResume(owner: LifecycleOwner) {
-                playerView.onResume()
-            }
+            override fun onResume(owner: LifecycleOwner) = playerView.onResume()
 
-            override fun onPause(owner: LifecycleOwner) {
-                playerView.onPause()
-            }
+            override fun onPause(owner: LifecycleOwner) = playerView.onPause()
 
-            override fun onStop(owner: LifecycleOwner) {
-                playerView.onStop()
-            }
+            override fun onStop(owner: LifecycleOwner) = playerView.onStop()
 
             override fun onDestroy(owner: LifecycleOwner) = dispose()
         }

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/Util.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/Util.kt
@@ -1,8 +1,5 @@
 package com.bitmovin.player.flutter
 
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import android.os.Handler
 import android.os.Looper
 
@@ -28,10 +25,3 @@ inline fun postToMainThread(crossinline block: () -> Unit?) {
         block()
     }
 }
-
-fun Context.requireActivity(): Activity =
-    when (this) {
-        is Activity -> this
-        is ContextWrapper -> baseContext.requireActivity()
-        else -> error("No activity found for context $this")
-    }

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/Util.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/Util.kt
@@ -1,5 +1,8 @@
 package com.bitmovin.player.flutter
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Handler
 import android.os.Looper
 
@@ -25,3 +28,10 @@ inline fun postToMainThread(crossinline block: () -> Unit?) {
         block()
     }
 }
+
+fun Context.requireActivity(): Activity =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.requireActivity()
+        else -> error("No activity found for context $this")
+    }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Similar to RN wrapper [before this PR](https://github.com/bitmovin/bitmovin-player-react-native/pull/313) the `PlayerView`'s lifecycle handling is missing and so the player doesn't pause when app goes to the background.

This PR is also prework for PiP implementation, as we will need activity reference to implement it.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Add `Context.requireActivity()` to get activity reference from the Context
- Add lifecycle handling using the LifecycleOwner pattern

## Tests
<!-- Reference unit tests and/or system tests here or explain why testing is not possible/applicable. -->
<!-- See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [ ] 📢 New public API is fully documented
