### PR TITLE
Introduce onPictureInPictureModeChanged to FlutterPlayerView (PiP #2)

### DIFF
--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -40,7 +40,7 @@ class FlutterPlayerView(
         )
 
     private val activity = context.requireActivity()
-    private val playerView: PlayerView = PlayerView(context, player = null)
+    private val playerView = PlayerView(context, player = null)
     private var isInPictureInPictureMode = activity.isInPictureInPictureMode
     private val configurationChangedCallback =
         object : ComponentCallbacks {

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.view.View
-import android.widget.FrameLayout
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.bitmovin.player.PlayerView
@@ -127,11 +126,11 @@ class FlutterPlayerView(
         // To work around this limitation we listen to configuration changes and check if the PiP mode changed.
         // Since Flutter's PlatformView isn't actually an Android View,
         // we unfortunately cannot just override onConfigurationChanged function.
-        // Instead, we add an invisible FrameLayout to the PlayerView and override its onConfigurationChanged function.
-        // The alternative would be registering a ComponentCallbacks object to the activity, which unfortunatley doesn't
+        // Instead, we add a blank View to the PlayerView and override its onConfigurationChanged function.
+        // The alternative would be registering a ComponentCallbacks object to the activity, which unfortunately doesn't
         // work for some Android versions (tested on Android 10 with FlutterFragmentActivity).
         addView(
-            object : FrameLayout(context) {
+            object : View(context) {
                 override fun onConfigurationChanged(newConfig: Configuration) {
                     if (isInPictureInPictureMode != activity.isInPictureInPictureMode) {
                         isInPictureInPictureMode = activity.isInPictureInPictureMode

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -3,8 +3,8 @@ package com.bitmovin.player.flutter
 import android.app.Activity
 import android.content.ComponentCallbacks
 import android.content.Context
-import android.content.res.Configuration
 import android.content.ContextWrapper
+import android.content.res.Configuration
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -121,13 +121,13 @@ class FlutterPlayerView(
 
     private fun PlayerView.setOnPictureInPictureModeChanged(callback: (Boolean, Configuration) -> Unit) {
         var isInPictureInPictureMode = activity.isInPictureInPictureMode
-        // Listening to PiP changes usually happens by overriding onPictureInPictureModeChanged in the Activity.
-        // This is not really doable in a SDK context since the library consumer actually controls the activity.
+        // Listening to PiP changes usually happens by overriding `onPictureInPictureModeChanged` in the activity.
+        // This is not doable in an SDK context since the library consumer controls the activity.
         // To work around this limitation we listen to configuration changes and check if the PiP mode changed.
-        // Since Flutter's PlatformView isn't actually an Android View,
-        // we unfortunately cannot just override onConfigurationChanged function.
-        // Instead, we add a blank View to the PlayerView and override its onConfigurationChanged function.
-        // The alternative would be registering a ComponentCallbacks object to the activity, which unfortunately doesn't
+        // Since Flutter's `PlatformView` isn't actually an Android `View`,
+        // we unfortunately cannot just override the `onConfigurationChanged` function.
+        // Instead, we add a blank `View` to the `PlayerView` and override its `onConfigurationChanged` function.
+        // The alternative would be registering a `ComponentCallbacks` object to the activity, which unfortunately doesn't
         // work for some Android versions (tested on Android 10 with FlutterFragmentActivity).
         addView(
             object : View(context) {

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -119,7 +119,7 @@ class FlutterPlayerView(
         sink = null
     }
 
-    private fun PlayerView.setOnPictureInPictureModeChanged(callback: (Boolean, Configuration) -> Unit) {
+    private fun PlayerView.setOnPictureInPictureModeChangedCallback(callback: (Boolean, Configuration) -> Unit) {
         var isInPictureInPictureMode = activity.isInPictureInPictureMode
         // Listening to PiP changes usually happens by overriding `onPictureInPictureModeChanged` in the activity.
         // This is not doable in an SDK context since the library consumer controls the activity.

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/FlutterPlayerView.kt
@@ -123,12 +123,14 @@ class FlutterPlayerView(
         var isInPictureInPictureMode = activity.isInPictureInPictureMode
         // Listening to PiP changes usually happens by overriding `onPictureInPictureModeChanged` in the activity.
         // This is not doable in an SDK context since the library consumer controls the activity.
+        // It's also possible to set a `addOnPictureInPictureModeChangedListener` to the activity that
+        // implements `OnPictureInPictureModeChangedProvider`, unfortunately `FlutterActvity` doesn't implement it.
         // To work around this limitation we listen to configuration changes and check if the PiP mode changed.
         // Since Flutter's `PlatformView` isn't actually an Android `View`,
         // we unfortunately cannot just override the `onConfigurationChanged` function.
         // Instead, we add a blank `View` to the `PlayerView` and override its `onConfigurationChanged` function.
-        // The alternative would be registering a `ComponentCallbacks` object to the activity, which unfortunately doesn't
-        // work for some Android versions (tested on Android 10 with FlutterFragmentActivity).
+        // The alternative would be registering a `ComponentCallbacks` object to the activity,
+        // which doesn't work for some Android versions (tested on Android 10 with FlutterFragmentActivity).
         addView(
             object : View(context) {
                 override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
_There is currently no way to get notified from the OS that PiP mode has been activated._

Listening to PiP changes usually happens by overriding [onPictureInPictureModeChanged](https://developer.android.com/reference/android/app/Activity#onPictureInPictureModeChanged(boolean,%20android.content.res.Configuration)) in the Activity. This is not really doable in a SDK context since the library consumer actually controls the activity.
 
~~To work around this issue, this PR introduces a `ComponentCallbacks` instance registered to an instance of the Activity, this way we can get notified about configuration changes.~~ 
Edit: unfortunately, component callbacks don't work for some Android versions (tested on Android 10 with FlutterFragmentActivity). My suspicion is that it's an issue in Flutter's activity - since one can also observe activity getting a red color overlay.

The configuration change listening is now done by overriding view's `onConfigurationChanged`. Since Flutter's PlatformView isn't actually an Android View we have to add a blank view to the PlayerView in order to be able to override the mentioned function.

In combination with [activity.isInPictureInPictureMode](https://developer.android.com/reference/android/app/Activity#isInPictureInPictureMode()) we can imitate Activity's onPictureInPictureModeChanged.

This PR is prework for PiP implementation.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Added and registered a ”fake" `onPictureInPictureModeChanged` callback

## Tests
<!-- Reference unit tests and/or system tests here or explain why testing is not possible/applicable. -->
<!-- See checklist below for details. -->

## Checklist (for PR submitters and reviewers)
- [ ] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [ ] 📢 New public API is fully documented
