### PR TITLE
Automated releases

### DIFF
--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -1,0 +1,103 @@
+name: Finish Release Train
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+env:
+  LC_ALL: en_US.UTF-8
+  LANG: en_US.UTF-8
+
+concurrency:
+  group: finish-release-train-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  create_pr:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-latest
+    outputs:
+      version_number: ${{ steps.version_number.outputs.version_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect version number
+        id: version_number
+        run: |
+          version_number="$(jq --raw-output '.version' package.json)"
+          echo "Detected version number: $version_number"
+          echo "version_number=$version_number" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        run: |
+          gh pr create \
+          --base "development" \
+          --head "main" \
+          --title "Finish release ${{ steps.version_number.outputs.version_number }}" \
+          --body "Finish release ${{ steps.version_number.outputs.version_number }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  publish_release:
+    needs: [create_pr]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Git User
+        run: |
+          # setup git
+          git config --global user.name "Bitmovin Release Automation"
+          git config --global user.email "support@bitmovin.com"
+
+      - name: Add tag
+        run: |
+          git tag v${{ needs.create_pr.outputs.version_number }}
+
+      - name: Git push
+        run: |
+          git push origin v${{ needs.create_pr.outputs.version_number }}
+
+      - name: Setup node and npm registry
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build TypeScript files
+        run: yarn build
+
+      - name: Publish npm package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract changelog
+        id: changelog
+        uses: ffurrer2/extract-release-notes@v1
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ needs.create_pr.outputs.version_number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: ${{ steps.changelog.outputs.release_notes }}
+
+  publish_documentation:
+    needs: [publish_release]
+    name: Generate API Documentation
+    uses: ./.github/workflows/generate-documentation.yml
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GCS_ACCOUNT: ${{ secrets.GCS_ACCOUNT }}
+      CF_TOKEN: ${{ secrets.CF_TOKEN }}
+      CF_ZONEID: ${{ secrets.CF_ZONEID }}

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -1,4 +1,5 @@
 name: Finish Release Train
+
 on: workflow_dispatch
 
 env:

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -54,6 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           ssh-key: ${{ secrets.PLAYER_FLUTTER_DEPLOY_KEY }}
 
       - name: Setup Git User
@@ -75,6 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Setup Git User
         run: |

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -1,103 +1,89 @@
 name: Finish Release Train
-on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+on: workflow_dispatch
 
 env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
 
 concurrency:
-  group: finish-release-train-${{ github.ref_name }}
+  group: finish-release-train-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  create_pr:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v')
+  prepare:
+    name: Extracts the version number from the release branch
     runs-on: ubuntu-latest
     outputs:
       version_number: ${{ steps.version_number.outputs.version_number }}
     steps:
+      - name: Verify release branch
+        if: "!contains(github.ref, 'release')"
+        run: exit 1
+
       - uses: actions/checkout@v4
+
+      - name: Setup Git User
+        run: |
+          git config --global user.name "Bitmovin Release Automation"
+          git config --global user.email "support@bitmovin.com"
 
       - name: Detect version number
         id: version_number
         run: |
-          version_number="$(jq --raw-output '.version' package.json)"
+          version_number=$(echo "${{ github.ref }}" | rev | cut -d '/' -f1 | rev)
           echo "Detected version number: $version_number"
           echo "version_number=$version_number" >> $GITHUB_OUTPUT
 
-      - name: Create PR
+      - name: Update Changelog
         run: |
-          gh pr create \
-          --base "development" \
-          --head "main" \
-          --title "Finish release ${{ steps.version_number.outputs.version_number }}" \
-          --body "Finish release ${{ steps.version_number.outputs.version_number }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+          sed -i "s/\[${{ steps.version_number.outputs.version_number }}\].*/\[${{ steps.version_number.outputs.version_number }}\] $(date +'%Y-%m-%d')/g" CHANGELOG.md
 
-  publish_release:
-    needs: [create_pr]
+      - name: Commit changelog version bump
+        run: |
+          git add CHANGELOG.md
+          git commit -m "chore: bump changelog date to today"
+          git push origin ${{ github.ref }}
+
+  trigger_publish:
+    needs: [prepare]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.PLAYER_FLUTTER_DEPLOY_KEY }}
 
       - name: Setup Git User
         run: |
-          # setup git
           git config --global user.name "Bitmovin Release Automation"
           git config --global user.email "support@bitmovin.com"
 
       - name: Add tag
         run: |
-          git tag v${{ needs.create_pr.outputs.version_number }}
+          git tag ${{ needs.prepare.outputs.version_number }}
 
-      - name: Git push
+      - name: Push tag
         run: |
-          git push origin v${{ needs.create_pr.outputs.version_number }}
+          git push origin ${{ needs.prepare.outputs.version_number }}
 
-      - name: Setup node and npm registry
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          registry-url: 'https://registry.npmjs.org/'
-          cache: 'yarn'
+  create_pr:
+    needs: [trigger_publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Setup Git User
+        run: |
+          git config --global user.name "Bitmovin Release Automation"
+          git config --global user.email "support@bitmovin.com"
 
-      - name: Build TypeScript files
-        run: yarn build
-
-      - name: Publish npm package
-        run: npm publish
+      - name: Create PR
+        run: |
+          gh pr create \
+          --base "main" \
+          --title "Release ${{ needs.prepare.outputs.version_number }}" \
+          --body "Release ${{ needs.prepare.outputs.version_number }}. Please review and merge this PR." \
+          --reviewer "${{ github.actor }}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Extract changelog
-        id: changelog
-        uses: ffurrer2/extract-release-notes@v1
-
-      - name: Create GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: v${{ needs.create_pr.outputs.version_number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: ${{ steps.changelog.outputs.release_notes }}
-
-  publish_documentation:
-    needs: [publish_release]
-    name: Generate API Documentation
-    uses: ./.github/workflows/generate-documentation.yml
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      GCS_ACCOUNT: ${{ secrets.GCS_ACCOUNT }}
-      CF_TOKEN: ${{ secrets.CF_TOKEN }}
-      CF_ZONEID: ${{ secrets.CF_ZONEID }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -46,6 +46,7 @@ jobs:
           git push origin ${{ github.ref }}
 
   trigger_publish:
+    name: Push tag to trigger publishing to pub dev
     needs: [prepare]
     runs-on: ubuntu-latest
     permissions:
@@ -69,7 +70,8 @@ jobs:
           git push origin ${{ needs.prepare.outputs.version_number }}
 
   create_pr:
-    needs: [trigger_publish]
+    name: Create PR
+    needs: [prepare, trigger_publish]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Update Changelog
         run: |
-          sed -i "s/\[${{ steps.version_number.outputs.version_number }}\].*/\[${{ steps.version_number.outputs.version_number }}\] $(date +'%Y-%m-%d')/g" CHANGELOG.md
+          sed -i "s/\[${{ steps.version_number.outputs.version_number }}\].*/\[${{ steps.version_number.outputs.version_number }}\] - $(date +'%Y-%m-%d')/g" CHANGELOG.md
 
       - name: Commit changelog version bump
         run: |

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Install CI scripts
         run: |
           curl -sS -H "Authorization: token ${GH_TOKEN}" -L https://raw.githubusercontent.com/bitmovin-engineering/player-ci/master/install.sh | bash
-      # TODO: commented out for testing
-      # - name: Upload to CDN
-      #   run: node ./ci_scripts/src/uploadToGcs.js flutter ../../doc/api
-      # - name: Purge CDN cache
-      #   run: node ./ci_scripts/src/purgeCloudflarePath.js 'flutter'
+      - name: Upload to CDN
+        run: node ./ci_scripts/src/uploadToGcs.js flutter ../../doc/api
+      - name: Purge CDN cache
+        run: node ./ci_scripts/src/purgeCloudflarePath.js 'flutter'

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Install CI scripts
         run: |
           curl -sS -H "Authorization: token ${GH_TOKEN}" -L https://raw.githubusercontent.com/bitmovin-engineering/player-ci/master/install.sh | bash
-      - name: Upload to CDN
-        run: node ./ci_scripts/src/uploadToGcs.js flutter ../../doc/api
-      - name: Purge CDN cache
-        run: node ./ci_scripts/src/purgeCloudflarePath.js 'flutter'
+      # TODO: commented out for testing
+      # - name: Upload to CDN
+      #   run: node ./ci_scripts/src/uploadToGcs.js flutter ../../doc/api
+      # - name: Purge CDN cache
+      #   run: node ./ci_scripts/src/purgeCloudflarePath.js 'flutter'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,12 @@ on:
 
 jobs:
   publish:
-    permissions:
-      id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      environment: pub.dev
+    # TODO: commented out for manual testing of start-release-train.yml and stop-release-train.yml
+    # permissions:
+    #   id-token: write
+    # uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   environment: pub.dev
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Publishing to pub.dev"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
     needs: [publish]
     name: Generate API Documentation
     uses: ./.github/workflows/generate-documentation.yml
+    with:
+      version_number: ${{ github.ref_name }}
     secrets:
       PLAYER_CI_GH_TOKEN: ${{ secrets.PLAYER_CI_GH_TOKEN }}
       GCS_ACCOUNT: ${{ secrets.GCS_ACCOUNT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    name: Publish to pub.dev
     # TODO: commented out for testing
     # permissions:
     #   id-token: write
@@ -15,13 +16,16 @@ jobs:
     #   environment: pub.dev
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Publishing to pub.dev"
+      - run: echo "Publishing to pub.dev ${{ github.ref_name }}"
 
   create_gh_release:
+    name: Create GitHub release
     needs: [publish]
     runs-on: ubuntu-latest
     steps:
-      - name: Extract changelog
+      - uses: actions/checkout@v4
+
+      - name: Extract Changelog
         id: changelog
         uses: ffurrer2/extract-release-notes@v1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    # TODO: commented out for manual testing of start-release-train.yml and stop-release-train.yml
+    # TODO: commented out for testing
     # permissions:
     #   id-token: write
     # uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
@@ -16,3 +16,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Publishing to pub.dev"
+
+  create_gh_release:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract changelog
+        id: changelog
+        uses: ffurrer2/extract-release-notes@v1
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: ${{ steps.changelog.outputs.release_notes }}
+
+  publish_documentation:
+    needs: [publish]
+    name: Generate API Documentation
+    uses: ./.github/workflows/generate-documentation.yml
+    secrets:
+      PLAYER_CI_GH_TOKEN: ${{ secrets.PLAYER_CI_GH_TOKEN }}
+      GCS_ACCOUNT: ${{ secrets.GCS_ACCOUNT }}
+      CF_TOKEN: ${{ secrets.CF_TOKEN }}
+      CF_ZONEID: ${{ secrets.CF_ZONEID }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,15 +8,11 @@ on:
 jobs:
   publish:
     name: Publish to pub.dev
-    # TODO: commented out for testing
-    # permissions:
-    #   id-token: write
-    # uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    # with:
-    #   environment: pub.dev
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Publishing to pub.dev ${{ github.ref_name }}"
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev
 
   create_gh_release:
     name: Create GitHub release

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -1,4 +1,5 @@
 name: Start Release Train
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,12 +7,15 @@ on:
         description: 'Version number of the release'
         type: string
         required: true
+
 env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+
 concurrency:
   group: start-release-train-${{ inputs.version_number }}
   cancel-in-progress: true
+
 jobs:
   create_release_pr:
     name: Create release branch and bump version

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  create_release_pr:
+  create_release_branch:
     name: Create release branch and bump version
     runs-on: macos-latest
     outputs:

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Bump changelog version
         run: |
-          sed -i'.bak' "s/\[Unreleased\]/\[${{ inputs.version_number }}\] \(${{ inputs.release_date }}\)/g" CHANGELOG.md
+          sed -i'.bak' "s/\[Unreleased\]/\[${{ inputs.version_number }}\] ${{ inputs.release_date }}/g" CHANGELOG.md
           awk 'BEGIN {count=0} /## \[/ {count++; if (count == 2) exit} {print}' CHANGELOG.md
 
       - name: Bump package version

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -1,0 +1,85 @@
+name: Start Release Train
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number of the release'
+        type: string
+        required: true
+      release_date:
+        description: 'Date of the final release. Will be used for CHANGELOG.md (format YYYY-MM-DD, e.g. 2023-02-27)'
+        type: string
+        required: true
+      dry_run:
+        description: 'If true, the workflow will not create a PR'
+        type: boolean
+        required: false
+        default: false
+env:
+  LC_ALL: en_US.UTF-8
+  LANG: en_US.UTF-8
+concurrency:
+  group: start-release-train-${{ inputs.version_number }}
+  cancel-in-progress: true
+jobs:
+  create_release_pr:
+    name: Create release branch and bump version
+    runs-on: macos-latest
+    outputs:
+      branch_name: ${{ steps.branching.outputs.branch_name }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: ./.github/actions/prepare-dependencies
+
+      - name: Setup Git user
+        run: |
+          # setup git
+          git config --global user.name "Bitmovin Release Automation"
+          git config --global user.email "support@bitmovin.com"
+
+      - name: Set release branch name
+        id: branching
+        run: |
+          branch_name="release/${{ inputs.version_number }}"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "$branch_name"
+
+      - name: Create Release Branch
+        if: ${{ !inputs.dry_run }}
+        run: |
+          # Delete the release branch if already exists, useful in case we need to re-run this workflow
+          git push origin --delete ${{ steps.branching.outputs.branch_name }} || true
+          git checkout -b ${{ steps.branching.outputs.branch_name }}
+
+      - name: Bump changelog version
+        run: |
+          sed -i'.bak' "s/\[Unreleased\]/\[${{ inputs.version_number }}\] \(${{ inputs.release_date }}\)/g" CHANGELOG.md
+          awk 'BEGIN {count=0} /## \[/ {count++; if (count == 2) exit} {print}' CHANGELOG.md
+
+      - name: Bump package version
+        run: | 
+          dart pub global activate cider
+          dart pub global run cider version ${{ inputs.version_number }}
+          flutter pub get
+
+      - name: Install pods to update Podfile.lock
+        run: (cd example/ios && pod install --repo-update)
+
+      - name: Commit version bump
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git add CHANGELOG.md pubspec.yaml example/ios/Podfile.lock example/pubspec.lock
+          git commit -m "chore: prepare release ${{ inputs.version_number }}"
+          git push origin ${{ steps.branching.outputs.branch_name }}
+
+      - name: Create PR
+        if: ${{ !inputs.dry_run }}
+        run: |
+          gh pr create \
+          --base "main" \
+          --title "Release ${{ inputs.version_number }}" \
+          --body "Release ${{ inputs.version_number }}.\n\nPlease review and merge this PR to continue the release process." \
+          --reviewer "${{ github.actor }}"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -64,3 +64,17 @@ jobs:
           git add CHANGELOG.md pubspec.yaml example/ios/Podfile.lock example/pubspec.lock
           git commit -m "chore: prepare release ${{ inputs.version_number }}"
           git push origin ${{ steps.branching.outputs.branch_name }}
+
+  publish_dry_run:
+    name: Dry run for publishing to pub.dev
+    needs: create_release_branch
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          branch: ${{ needs.create_release_branch.outputs.branch_name }}
+
+      - uses: ./.github/actions/prepare-dependencies
+
+      - name: Publish dry run
+        run: dart pub publish --dry-run

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -57,7 +57,8 @@ jobs:
           flutter pub get
 
       - name: Install pods to update Podfile.lock
-        run: (cd example/ios && pod install --repo-update)
+        working-directory: example/ios
+        run: pod install --repo-update
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -79,7 +79,7 @@ jobs:
           gh pr create \
           --base "main" \
           --title "Release ${{ inputs.version_number }}" \
-          --body "Release ${{ inputs.version_number }}.\n\nPlease review and merge this PR to continue the release process." \
+          --body "Release ${{ inputs.version_number }}. Please review and merge this PR to continue the release process." \
           --reviewer "${{ github.actor }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -6,11 +6,6 @@ on:
         description: 'Version number of the release'
         type: string
         required: true
-      dry_run:
-        description: 'If true, the workflow will not create a PR'
-        type: boolean
-        required: false
-        default: false
 env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
@@ -30,7 +25,6 @@ jobs:
 
       - name: Setup Git user
         run: |
-          # setup git
           git config --global user.name "Bitmovin Release Automation"
           git config --global user.email "support@bitmovin.com"
 
@@ -42,7 +36,6 @@ jobs:
           echo "$branch_name"
 
       - name: Create Release Branch
-        if: ${{ !inputs.dry_run }}
         run: |
           # Delete the release branch if already exists, useful in case we need to re-run this workflow
           git push origin --delete ${{ steps.branching.outputs.branch_name }} || true
@@ -63,19 +56,7 @@ jobs:
         run: (cd example/ios && pod install --repo-update)
 
       - name: Commit version bump
-        if: ${{ !inputs.dry_run }}
         run: |
           git add CHANGELOG.md pubspec.yaml example/ios/Podfile.lock example/pubspec.lock
           git commit -m "chore: prepare release ${{ inputs.version_number }}"
           git push origin ${{ steps.branching.outputs.branch_name }}
-
-      - name: Create PR
-        if: ${{ !inputs.dry_run }}
-        run: |
-          gh pr create \
-          --base "main" \
-          --title "Release ${{ inputs.version_number }}" \
-          --body "Release ${{ inputs.version_number }}. Please review and merge this PR to continue the release process." \
-          --reviewer "${{ github.actor }}"
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          branch: ${{ needs.create_release_branch.outputs.branch_name }}
+          ref: ${{ needs.create_release_branch.outputs.branch_name }}
 
       - uses: ./.github/actions/prepare-dependencies
 

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -6,10 +6,6 @@ on:
         description: 'Version number of the release'
         type: string
         required: true
-      release_date:
-        description: 'Date of the final release. Will be used for CHANGELOG.md (format YYYY-MM-DD, e.g. 2023-02-27)'
-        type: string
-        required: true
       dry_run:
         description: 'If true, the workflow will not create a PR'
         type: boolean
@@ -54,7 +50,7 @@ jobs:
 
       - name: Bump changelog version
         run: |
-          sed -i'.bak' "s/\[Unreleased\]/\[${{ inputs.version_number }}\] ${{ inputs.release_date }}/g" CHANGELOG.md
+          sed -i'.bak' "s/\[Unreleased\]/\[${{ inputs.version_number }}\]/g" CHANGELOG.md
           awk 'BEGIN {count=0} /## \[/ {count++; if (count == 2) exit} {print}' CHANGELOG.md
 
       - name: Bump package version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-### Added
-- Support for automated releases
 
 ## [0.4.0] - 2023-12-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for automated releases
 
 ## [0.4.0] - 2023-12-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for automated released (TODO: remove again)
 
 ## [0.4.0] - 2023-12-12
 ### Added
-Support for Picture-in-Picture (PiP) playback on iOS
+- Support for Picture-in-Picture (PiP) playback on iOS
   - `PictureInPictureEnter` which is emitted when the player view is about to enter Picture-in-Picture mode
   - `PictureInPictureExit` which is emitted when the player view is about to exit Picture-in-Picture mode
   - `PictureInPictureEntered` which is emitted when the player view finishes entering Picture-in-Picture mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-### Added
-- Support for automated released (TODO: remove again)
 
 ## [0.4.0] - 2023-12-12
 ### Added

--- a/ios/bitmovin_player.podspec
+++ b/ios/bitmovin_player.podspec
@@ -1,15 +1,12 @@
-#
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
-# Run `pod lib lint player.podspec` to validate before publishing.
-#
+require 'yaml'
+
+package = YAML.load(File.read(File.join(__dir__, "../pubspec.yaml")))
+
 Pod::Spec.new do |s|
-  s.name = 'bitmovin_player'
-  s.version = '0.4.0'
-  s.summary = 'Bitmovin Player Flutter plugin'
-  s.description = <<-DESC
-Flutter plugin for Bitmovin Player.
-                  DESC
-  s.homepage = 'https://bitmovin.com'
+  s.name = package['name']
+  s.version = package['version']
+  s.summary = package['description']
+  s.homepage = package['homepage']
   s.license = { :file => '../LICENSE' }
   s.author = { 'Bitmovin' => 'support@bitmovin.com' }
   s.source = { :path => '.' }


### PR DESCRIPTION
## Description
Adds automation using GH actions for the whole release process.

## Changes
- Add workflow `start-release-train.yml`
    - Creates the release branch
    - Bumps the version in all necessary places
    - Does a publish dry-run: `dart pub publish --dry-run`
    - Test run: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7287704111
- Add workflow `finish-release-train.yml`
    - Adds the release date to CHANGELOG.md
    - Pushes a version tag to trigger the actual publishing of the package (this is a requirement of `dart-lang/setup-dart/.github/workflows/publish.yml@v1`)
    - Creates a PR to merge release branch, including version tag, back to main
    - Test run: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7287786241
- Add workflow `publish.yml`
   - Based on this guide: https://dart.dev/tools/pub/automated-publishing
   - When a version tag is pushed, publishes the package to `pub.dev`
   - Creates the according GH release
   - Generates the API doc and uploads it to Bitmovin's CDN
   - Test run: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7287788834

Sidenote: The GH release, release branch, merge PR, and tag, that were created by the test run are deleted already again, to have a clean repo state.

## Tests
n/a

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes: n/a as only internal changes
- [x] 🧪 Tests added and/or updated: n/a
- [x] 📢 New public API is fully documented
