### PR TITLE
Fix workflow for publishing to pub.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       # manually log-in in to pub.dev with an admin account.
       - uses: dart-lang/setup-dart@v1.6.0
 
-      - name: Publish - dry run
+      - name: Publish dry run
         run: dart pub publish --dry-run
 
       - name: Publish to pub.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   # This job is based on dart-lang/setup-dart/.github/workflows/publish.yml@v1, which cannot be used here as it only
-  # support publishing pure Dart packages and not Flutter packages.
+  # supports publishing pure Dart packages and not Flutter packages.
   publish:
     name: Publish to pub.dev
     environment: pub.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,13 +6,28 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
+  # This job is based on dart-lang/setup-dart/.github/workflows/publish.yml@v1, which cannot be used here as it only
+  # support publishing pure Dart packages and not Flutter packages.
   publish:
     name: Publish to pub.dev
+    environment: pub.dev
     permissions:
-      id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      environment: pub.dev
+      id-token: write # This is required for requesting the JWT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/prepare-dependencies
+
+      # Setup Dart SDK with JWT token. This is needed to allow publishing to pub.dev from the CI without having to 
+      # manually log-in in to pub.dev with an admin account.
+      - uses: dart-lang/setup-dart@v1.6.0
+
+      - name: Publish - dry run
+        run: dart pub publish --dry-run
+
+      - name: Publish to pub.dev
+        run: dart pub publish -f
 
   create_gh_release:
     name: Create GitHub release


### PR DESCRIPTION
## Description
The [re-usable workflow](https://github.com/dart-lang/setup-dart/blob/main/.github/workflows/publish.yml) that was used so far only supports publishing pure Dart packages but we have to publish a Flutter package.

## Changes
Rewrite the `publish.yml` workflow to use a custom `publish` job that is based on the [official workflow to publish pure Dart packages](https://github.com/dart-lang/setup-dart/blob/main/.github/workflows/publish.yml)  and on [this](https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pubdev) guide.

## Tests
n/a

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes: n/a
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
