### PR TITLE
Mark GH releases done by CI as pre-release for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
           tag: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ steps.changelog.outputs.release_notes }}
+          prerelease: true
 
   publish_documentation:
     needs: [publish]


### PR DESCRIPTION
## Description
Each release should be marked as pre-release on GH. The recently introduced release automation was not doing this.

## Changes
Mark GH releases done by `publish.yml` as pre-release.

## Tests
n/a

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes: n/a
- [x] 🧪 Tests added and/or updated: n/a
- [x] 📢 New public API is fully documented
