### PR TITLE
Add workflow to open PR for player SDK update

### DIFF
--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -49,7 +49,7 @@ jobs:
           sed -i '' "s/s.dependency 'BitmovinPlayer', '.*/s.dependency 'BitmovinPlayer', '${{ inputs.version_number }}'/g" ios/bitmovin_player.podspec
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git
           cd example/ios
-          pod install --repo-update
+          pod install --repo-update || pod update --silent
 
       - name: Bump Android player SDK version
         if: ${{ inputs.sdk_name == 'android' }}

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Bump iOS player SDK version
         if: ${{ inputs.sdk_name == 'ios' }}
         run: |
-          sed -i '' 's/s.dependency "BitmovinPlayer", ".*/s.dependency "BitmovinPlayer", "${{ inputs.version_number }}"/g' ios/bitmovin_player.podspec
+          sed -i '' "s/s.dependency 'BitmovinPlayer', '.*/s.dependency 'BitmovinPlayer', '${{ inputs.version_number }}'/g" ios/bitmovin_player.podspec
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git
           cd example/ios
           pod install --repo-update

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -2,9 +2,67 @@ name: Create SDK update PR
 
 on:
   workflow_dispatch:
+    inputs:
+      sdk_name:
+        description: 'The SDK for which the version should be updated'
+        required: true
+        type: choice
+        options:
+          - android
+          - ios
+      version_number:
+        description: 'The version number to which the SDK should be updated'
+        required: true
+        type: string
 
 jobs:
-  dummy:
-    runs-on: ubuntu-latest
+  update:
+    name: Update SDK version
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ secrets.PLAYER_CI_GH_TOKEN }}
     steps:
-      - run: echo "Hello world"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup git user
+        run: |
+          git config --global user.name "Update Bot"
+          git config --global user.email "update-bot@bitmovin.com"
+
+      - name: Set update branch name
+        id: branching
+        run: |
+          branch_name="update_${{ inputs.sdk_name }}_player_to_${{ inputs.version_number }}"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Create update branch
+        run: |
+          git push origin --delete ${{ steps.branching.outputs.branch_name }} || true
+          git checkout -b ${{ steps.branching.outputs.branch_name }}
+
+      - name: Bump iOS player SDK version
+        if: ${{ inputs.sdk_name == 'ios' }}
+        run: |
+          sed -i '' 's/s.dependency "BitmovinPlayer", ".*/s.dependency "BitmovinPlayer", "${{ inputs.version_number }}"/g' ios/bitmovin_player.podspec
+          pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git
+          cd example/ios
+          pod install --repo-update
+
+      - name: Bump Android player SDK version
+        if: ${{ inputs.sdk_name == 'android' }}
+        run: |
+          sed -i '' "s/com.bitmovin.player:player:.*/com.bitmovin.player:player:${{ inputs.version_number }}'/g" android/build.gradle
+
+      - name: Commit version bump
+        run: |
+          git add ios/bitmovin_player.podspec android/build.gradle example/ios/Podfile.lock
+          git commit -m "chore(${{ inputs.sdk_name }}): update ${{ inputs.sdk_name }} player version to ${{ inputs.version_number }}"
+          git push origin ${{ steps.branching.outputs.branch_name }}
+
+      - name: Create PR
+        run: |
+          gh pr create \
+          --base "${{ github.ref }}" \
+          --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
+          --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -41,6 +41,8 @@ jobs:
           git push origin --delete ${{ steps.branching.outputs.branch_name }} || true
           git checkout -b ${{ steps.branching.outputs.branch_name }}
 
+      - uses: ./.github/actions/prepare-dependencies
+
       - name: Bump iOS player SDK version
         if: ${{ inputs.sdk_name == 'ios' }}
         run: |


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
These changes enable to open a PR with player dependency update whenever there is a new player version for Android or iOS.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Introduced `create-sdk-update-pr.yml` which is triggered via our release workflows from both the Android and the iOS player projects.
This then opens a PR with the needed changes to update the given player to the new version.

## Tests
<!-- Reference unit tests and/or system tests here or explain why testing is not possible/applicable. -->
<!-- See checklist below for details. -->
Jobs were triggered manually:
- Android: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7666171940/job/20893437339
- iOS: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7666926476

PRs were created by those jobs:
- Android: https://github.com/bitmovin/bitmovin-player-flutter/pull/101
- iOS: https://github.com/bitmovin/bitmovin-player-flutter/pull/102

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes - N/A
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
