### PR TITLE
Use M1 mac GitHub Actions runners on CI 

### DIFF
--- a/.github/workflows/build-workspace.yml
+++ b/.github/workflows/build-workspace.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   analyze_source_code:
     name: Analyze Source Code
-    runs-on: macos-latest
+    runs-on: macos-14
     concurrency:
       group: build-workspace-analyze-${{ inputs.ref || github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -30,7 +30,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
   build_ios:
     name: Build for iOS
-    runs-on: macos-latest
+    runs-on: macos-14
     concurrency:
       group: build-workspace-ios-${{ inputs.ref || github.event.pull_request.number || github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   update:
     name: Update SDK version
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.PLAYER_CI_GH_TOKEN }}
     steps:

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -19,12 +19,12 @@ concurrency:
 jobs:
   create_release_branch:
     name: Create release branch and bump version
-    runs-on: macos-latest
+    runs-on: macos-14
     outputs:
       branch_name: ${{ steps.branching.outputs.branch_name }}
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: ./.github/actions/prepare-dependencies
 
       - name: Setup Git user
@@ -51,7 +51,7 @@ jobs:
           awk 'BEGIN {count=0} /## \[/ {count++; if (count == 2) exit} {print}' CHANGELOG.md
 
       - name: Bump package version
-        run: | 
+        run: |
           dart pub global activate cider
           dart pub global run cider version ${{ inputs.version_number }}
           flutter pub get
@@ -69,7 +69,7 @@ jobs:
   publish_dry_run:
     name: Dry run for publishing to pub.dev
     needs: create_release_branch
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
GitHub introduced M1 macOS runners for open source repos, announced [here](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/).
We can now use them for free to speed up our workflows running on macOS.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated all workflows using macOS runners to use the new `macos-14` runner.

Checks ran for 3m: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7744004988
Compared to previous best 6m: https://github.com/bitmovin/bitmovin-player-flutter/actions/runs/7655869320


## Checklist (for PR submitters and reviewers)
- [ ] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [ ] 📢 New public API is fully documented
