### PR TITLE
Handle player view main actor isolation

### DIFF
--- a/ios/Classes/FlutterPlayerView.swift
+++ b/ios/Classes/FlutterPlayerView.swift
@@ -42,7 +42,7 @@ internal class FlutterPlayerView: NSObject, FlutterPlatformView {
         methodChannel.setMethodCallHandler(handleMethodCall)
         eventChannel.setStreamHandler(self)
         PlayerManager.shared.onPlayerCreated(id: arguments.playerId) { [weak self] player in
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
                 self?.createPlayerView(
                     player: player,
                     hasFullscreenHandler: arguments.hasFullscreenHandler,


### PR DESCRIPTION
## Description
Starting with iOS Bitmovin Player `3.78.0`, `PlayerView` is main actor isolated. This PR takes care of this.

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes: n/a
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
