### PR TITLE
Document race condition and produce meaningful error

### DIFF
--- a/lib/src/platform/player_view_platform_method_channel.dart
+++ b/lib/src/platform/player_view_platform_method_channel.dart
@@ -94,7 +94,7 @@ class PlayerViewPlatformMethodChannel extends PlayerViewPlatformInterface {
   // TODO(mario): Method channels are created only once `_onPlatformViewCreated`
   // is called. Calls to `_invokeMethod` that happen before that lead to an
   // error. This race condition can be fixed the same way as for
-  // PlayerPlatformMethodChannel` by using an `_initializationResult`.
+  // `PlayerPlatformMethodChannel` by using an `_initializationResult`.
   void _onPlatformViewCreated(int id) {
     _methodChannel = ChannelManager.registerMethodChannel(
       name: '${Channels.playerView}-$id',


### PR DESCRIPTION
## Description
- Make `_methodChannel` optional and introduce null check to avoid "LateInitializationError" when accessing method channel before it becomes available
    - Produce meaningful error instead
- Document potential race condition

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes: n/a
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
