### PR TITLE
Support casting for Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Support for `Player.isPaused` and `Player.isMuted`
 
 ## [0.13.0] - 2024-11-26
-- Introduce platform support for web
+- Introduce platform support for Web
   - Supported API calls: `loadSource(source)`, `play`, `pause`, `mute`, `unmute`, `seek(time)`, `timeShift(timeShift)`, `getCurrentTime`, `getTimeShift`, `getDuration`, `getMaxTimeShift`, `isLive`, `isPlaying`, `isAirplayActive`, `isAirplayAvailable`, `castVideo`, `castStop`, `isCastAvailable`, `isCasting`, `showAirPlayTargetPicker`, `destroy`
   - Supported events: `play`,`playing`,`paused`,`timeChanged`,`seek`,`seeked`,`timeShift`,`timeShifted`,`playbackFinished`,`error`,`muted`,`unmuted`,`warning`,`ready`,`sourceLoaded`,`sourceUnloaded`
 - Update Bitmovin's native Android Player SDK version to `3.94.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+- Google Cast support for Web platform.
+
 ## [0.13.0] - 2024-11-26
 - Introduce platform support for web.
   - Supported API calls: `loadSource(source)`, `play`, `pause`, `mute`, `unmute`, `seek(time)`, `timeShift(timeShift)`, `getCurrentTime`, `getTimeShift`, `getDuration`, `getMaxTimeShift`, `isLive`, `isPlaying`, `isAirplayActive`, `isAirplayAvailable`, `castVideo`, `castStop`, `isCastAvailable`, `isCasting`, `showAirPlayTargetPicker`, `destroy`

--- a/lib/src/api/casting/bitmovin_cast_manager_api.dart
+++ b/lib/src/api/casting/bitmovin_cast_manager_api.dart
@@ -4,6 +4,9 @@ import 'package:bitmovin_player/bitmovin_player.dart';
 // ignore: one_member_abstracts
 abstract class BitmovinCastManagerApi {
   /// Sends the given `message` to the cast receiver.
+  /// On Android and iOS an optional `messageNamespace` can be provided on which
+  /// the message should be sent. Should there be a `messageNamespace` provided
+  /// on Web, it will be ignored.
   Future<void> sendMessage({
     required String message,
     String? messageNamespace,

--- a/lib/src/casting/bitmovin_cast_manager.dart
+++ b/lib/src/casting/bitmovin_cast_manager.dart
@@ -1,8 +1,5 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:bitmovin_player/src/casting/custom_cast_message.dart';
-import 'package:bitmovin_player/src/channel_manager.dart';
-import 'package:bitmovin_player/src/channels.dart';
-import 'package:bitmovin_player/src/methods.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_interface.dart';
 
 /// Singleton, providing access to GoogleCast related features.
 /// Retrieve the singleton instance using [initialize].
@@ -16,8 +13,9 @@ class BitmovinCastManager implements BitmovinCastManagerApi {
   /// features.
   /// If no options are provided, the default options will be used.
   ///
-  /// IMPORTANT: This should only be called when the Google Cast SDK is
-  /// available in the application.
+  /// IMPORTANT: On iOS and Android, this should only be called when the
+  /// Google Cast SDK is available and linked in the application.
+  /// For Web, loading the CAST SDK is handled automatically.
   static Future<BitmovinCastManager> initialize({
     BitmovinCastManagerOptions options = const BitmovinCastManagerOptions(),
   }) async {
@@ -30,26 +28,16 @@ class BitmovinCastManager implements BitmovinCastManagerApi {
     return _singleton = instance;
   }
 
-  final _mainChannel = ChannelManager.registerMethodChannel(
-    name: Channels.main,
-  );
-
   Future<void> _initialize(BitmovinCastManagerOptions options) =>
-      _mainChannel.invokeMethod<void>(
-        Methods.castManagerInitialize,
-        options.toJson(),
-      );
+      CastManagerPlatformInterface.instance.initializeCastManager(options);
 
   @override
   Future<void> sendMessage({
     required String message,
     String? messageNamespace,
   }) =>
-      _mainChannel.invokeMethod<void>(
-        Methods.castManagerSendMessage,
-        CustomCastMessage(
-          message: message,
-          messageNamespace: messageNamespace,
-        ).toJson(),
+      CastManagerPlatformInterface.instance.sendMessage(
+        message: message,
+        messageNamespace: messageNamespace,
       );
 }

--- a/lib/src/platform/cast_manager_platform_interface.dart
+++ b/lib/src/platform/cast_manager_platform_interface.dart
@@ -1,0 +1,31 @@
+import 'package:bitmovin_player/bitmovin_player.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_message_channel.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Platform interface for the cast manager.
+abstract class CastManagerPlatformInterface extends PlatformInterface
+    implements BitmovinCastManagerApi {
+  /// Constructs a [CastManagerPlatformInterface].
+  CastManagerPlatformInterface() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static CastManagerPlatformInterface _instance =
+      CastManagerPlatformMessageChannel();
+
+  /// The instance of [CastManagerPlatformInterface] to use.
+  ///
+  /// Defaults to [CastManagerPlatformMessageChannel].
+  static CastManagerPlatformInterface get instance => _instance;
+
+  /// Platform-specific implementations should set this with their own
+  /// platform-specific class that extends [CastManagerPlatformInterface]
+  /// when they register themselves.
+  static set instance(CastManagerPlatformInterface instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Initializes the cast manager with the given [options].
+  Future<void> initializeCastManager(BitmovinCastManagerOptions options);
+}

--- a/lib/src/platform/cast_manager_platform_message_channel.dart
+++ b/lib/src/platform/cast_manager_platform_message_channel.dart
@@ -1,0 +1,35 @@
+import 'package:bitmovin_player/src/api/casting/bitmovin_cast_manager_options.dart';
+import 'package:bitmovin_player/src/casting/custom_cast_message.dart';
+import 'package:bitmovin_player/src/channel_manager.dart';
+import 'package:bitmovin_player/src/channels.dart';
+import 'package:bitmovin_player/src/methods.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_interface.dart';
+
+/// An implementation of [CastManagerPlatformInterface] that uses method
+/// channels. This is currently used for iOS and Android.
+class CastManagerPlatformMessageChannel extends CastManagerPlatformInterface {
+  final _mainChannel = ChannelManager.registerMethodChannel(
+    name: Channels.main,
+  );
+
+  @override
+  Future<void> sendMessage({
+    required String message,
+    String? messageNamespace,
+  }) =>
+      _mainChannel.invokeMethod<void>(
+        Methods.castManagerSendMessage,
+        CustomCastMessage(
+          message: message,
+          messageNamespace: messageNamespace,
+        ).toJson(),
+      );
+
+  @override
+  Future<void> initializeCastManager(BitmovinCastManagerOptions options) {
+    return _mainChannel.invokeMethod<void>(
+      Methods.castManagerInitialize,
+      options.toJson(),
+    );
+  }
+}

--- a/lib/src/platform/web/bitmovin_player_platform_web.dart
+++ b/lib/src/platform/web/bitmovin_player_platform_web.dart
@@ -1,17 +1,18 @@
-// ignore: avoid_web_libraries_in_flutter
 import 'dart:html';
 import 'dart:ui_web' as ui;
 
 import 'package:bitmovin_player/bitmovin_player.dart';
 import 'package:bitmovin_player/src/channels.dart';
 import 'package:bitmovin_player/src/platform/bitmovin_player_platform_interface.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_interface.dart';
 import 'package:bitmovin_player/src/platform/player_platform_interface.dart';
 import 'package:bitmovin_player/src/platform/player_view_platform_interface.dart';
+import 'package:bitmovin_player/src/platform/web/cast_manager_platform_web.dart';
 import 'package:bitmovin_player/src/platform/web/player_platform_web.dart';
 import 'package:bitmovin_player/src/platform/web/player_view_platform_web.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-/// Implementation of the [BitmovinPlayerPlatformInterface] for the web
+/// Implementation of the [BitmovinPlayerPlatformInterface] for the Web
 /// platform.
 class BitmovinPlayerPlatformWeb extends BitmovinPlayerPlatformInterface {
   /// Constructs a [BitmovinPlayerPlatformWeb].
@@ -24,6 +25,7 @@ class BitmovinPlayerPlatformWeb extends BitmovinPlayerPlatformInterface {
 
   static void registerWith(Registrar registrar) {
     BitmovinPlayerPlatformInterface.instance = BitmovinPlayerPlatformWeb();
+    CastManagerPlatformInterface.instance = CastManagerPlatformWeb();
   }
 
   @override

--- a/lib/src/platform/web/bitmovin_player_web_api.dart
+++ b/lib/src/platform/web/bitmovin_player_web_api.dart
@@ -31,6 +31,7 @@ class BitmovinPlayerJs {
   external String getStreamType();
   external void showAirplayTargetPicker();
   external void on(String event, Function handler);
+  external void addMetadata(String metadataType, Object metadata);
 }
 
 @JS()
@@ -40,10 +41,12 @@ class PlayerConfigJs {
     String? key,
     PlaybackConfigJs? playback,
     LicensingConfigJs? licensing,
+    GoogleCastRemoteControlConfigJs? remotecontrol,
   });
   external String? get key;
   external PlaybackConfigJs? get playback;
   external LicensingConfigJs? get licensing;
+  external GoogleCastRemoteControlConfigJs? get remotecontrol;
 }
 
 @JS()
@@ -64,6 +67,34 @@ class LicensingConfigJs {
     int? delay,
   });
   external int? get delay;
+}
+
+@JS()
+@anonymous
+class GoogleCastRemoteControlConfigJs {
+  external factory GoogleCastRemoteControlConfigJs({
+    required String type,
+    String? receiverApplicationId,
+    String? messageNamespace,
+  });
+
+  // Factory method to allow having a default value for `type` when creating
+  // instances directly from Dart code.
+  // ignore: prefer_constructors_over_static_methods
+  static GoogleCastRemoteControlConfigJs create(
+    String? receiverApplicationId,
+    String? messageNamespace,
+  ) {
+    return GoogleCastRemoteControlConfigJs(
+      type: 'googlecast',
+      receiverApplicationId: receiverApplicationId,
+      messageNamespace: messageNamespace,
+    );
+  }
+
+  external String get type;
+  external String? get receiverApplicationId;
+  external String? get messageNamespace;
 }
 
 class StreamTypeJS {
@@ -136,4 +167,30 @@ class ErrorEventJs extends PlayerEventBaseJs {
 class WarningEventJs extends PlayerEventBaseJs {
   external int get code;
   external String? get message;
+}
+
+@JS()
+@anonymous
+class CastAvailableEventJs extends PlayerEventBaseJs {
+  external bool get receiverAvailable;
+}
+
+@JS()
+@anonymous
+class CastStartedEventJs extends PlayerEventBaseJs {
+  external String get deviceName;
+  external bool get resuming;
+}
+
+@JS()
+@anonymous
+class CastWaitingForDeviceEventJs extends PlayerEventBaseJs {
+  external CastPayloadJs get castPayload;
+}
+
+@JS()
+@anonymous
+class CastPayloadJs {
+  external double get currentTime;
+  external String? get deviceName;
 }

--- a/lib/src/platform/web/bitmovin_player_web_api.dart
+++ b/lib/src/platform/web/bitmovin_player_web_api.dart
@@ -33,7 +33,7 @@ class BitmovinPlayerJs {
   external String getStreamType();
   external void showAirplayTargetPicker();
   external void on(String event, Function handler);
-  external void addMetadata(String metadataType, Object metadata);
+  external bool addMetadata(String metadataType, Object metadata);
 }
 
 @JS()

--- a/lib/src/platform/web/cast_manager_platform_web.dart
+++ b/lib/src/platform/web/cast_manager_platform_web.dart
@@ -1,0 +1,24 @@
+import 'package:bitmovin_player/src/api/casting/bitmovin_cast_manager_options.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_interface.dart';
+
+/// An implementation of [CastManagerPlatformInterface] for the Web platform.
+class CastManagerPlatformWeb extends CastManagerPlatformInterface {
+  BitmovinCastManagerOptions? _options;
+  BitmovinCastManagerOptions? get options => _options;
+  void Function(String)? castMessageHandler;
+
+  @override
+  Future<void> sendMessage({
+    required String message,
+    String? messageNamespace,
+  }) {
+    castMessageHandler?.call(message);
+    return Future.value();
+  }
+
+  @override
+  Future<void> initializeCastManager(BitmovinCastManagerOptions options) {
+    _options = options;
+    return Future.value();
+  }
+}

--- a/lib/src/platform/web/conversion.dart
+++ b/lib/src/platform/web/conversion.dart
@@ -60,11 +60,21 @@ extension SourceFromJs on SourceJs {
 }
 
 extension PlayerConfigToJs on PlayerConfig {
-  PlayerConfigJs toPlayerConfigJs() {
+  PlayerConfigJs toPlayerConfigJs(BitmovinCastManagerOptions? castOptions) {
+    GoogleCastRemoteControlConfigJs? remoteControlConfigJs;
+
+    if (castOptions != null) {
+      remoteControlConfigJs = GoogleCastRemoteControlConfigJs.create(
+        castOptions.applicationId,
+        castOptions.messageNamespace,
+      );
+    }
+
     return PlayerConfigJs(
       key: key,
       playback: playbackConfig?.toPlaybackConfigJs(),
       licensing: licensingConfig?.toLicensingConfigJs(),
+      remotecontrol: remoteControlConfigJs,
     );
   }
 }
@@ -107,6 +117,14 @@ extension PlayerEventBaseConversion on PlayerEventBaseJs {
 
   SourceUnloadedEvent toSourceUnloadedEvent() {
     return SourceUnloadedEvent(timestamp: timestamp);
+  }
+
+  CastStartEvent toCastStartEvent() {
+    return CastStartEvent(timestamp: timestamp);
+  }
+
+  CastStoppedEvent toCastStoppedEvent() {
+    return CastStoppedEvent(timestamp: timestamp);
   }
 }
 
@@ -173,6 +191,33 @@ extension WarningEventConversion on WarningEventJs {
     return WarningEvent(
       code: code,
       message: message,
+      timestamp: timestamp,
+    );
+  }
+}
+
+extension CastAvailableEventConversion on CastAvailableEventJs {
+  CastAvailableEvent toCastAvailableEvent() {
+    return CastAvailableEvent(timestamp: timestamp);
+  }
+}
+
+extension CastStartedEventConversion on CastStartedEventJs {
+  CastStartedEvent toCastStartedEvent() {
+    return CastStartedEvent(
+      timestamp: timestamp,
+      deviceName: deviceName,
+    );
+  }
+}
+
+extension CastWaitingForDeviceEventConversion on CastWaitingForDeviceEventJs {
+  CastWaitingForDeviceEvent toCastWaitingForDeviceEvent() {
+    return CastWaitingForDeviceEvent(
+      castPayload: CastPayload(
+        currentTime: castPayload.currentTime,
+        deviceName: castPayload.deviceName,
+      ),
       timestamp: timestamp,
     );
   }

--- a/lib/src/platform/web/player_platform_web.dart
+++ b/lib/src/platform/web/player_platform_web.dart
@@ -7,6 +7,7 @@ import 'package:bitmovin_player/src/platform/web/bitmovin_player_web_api.dart';
 import 'package:bitmovin_player/src/platform/web/cast_manager_platform_web.dart';
 import 'package:bitmovin_player/src/platform/web/conversion.dart';
 import 'package:bitmovin_player/src/platform/web/player_web_event_handler.dart';
+import 'package:logger/logger.dart';
 import 'package:web/web.dart' as web;
 
 /// An implementation of [PlayerPlatformInterface] for the Web platform.
@@ -24,12 +25,16 @@ class PlayerPlatformWeb extends PlayerPlatformInterface {
 
     _playerEventHandler = PlayerWebEventHandler(_player, _onPlatformEvent);
     castManager.castMessageHandler = (String message) {
-      _player.addMetadata('CAST', message);
+      final result = _player.addMetadata('CAST', message);
+      if (!result) {
+        _logger.d('Failed to send CAST metadata to receiver');
+      }
     };
   }
 
   /// Unique identifier for this player instance.
   final String _playerId;
+  final Logger _logger = Logger();
   @override
   final PlayerConfig config;
   late BitmovinPlayerJs _player;

--- a/lib/src/platform/web/player_platform_web.dart
+++ b/lib/src/platform/web/player_platform_web.dart
@@ -1,13 +1,15 @@
 import 'dart:async';
 
 import 'package:bitmovin_player/bitmovin_player.dart';
+import 'package:bitmovin_player/src/platform/cast_manager_platform_interface.dart';
 import 'package:bitmovin_player/src/platform/player_platform_interface.dart';
 import 'package:bitmovin_player/src/platform/web/bitmovin_player_web_api.dart';
+import 'package:bitmovin_player/src/platform/web/cast_manager_platform_web.dart';
 import 'package:bitmovin_player/src/platform/web/conversion.dart';
 import 'package:bitmovin_player/src/platform/web/player_web_event_handler.dart';
 import 'package:web/web.dart' as web;
 
-/// An implementation of [PlayerPlatformInterface] for the web platform.
+/// An implementation of [PlayerPlatformInterface] for the Web platform.
 /// This is specific to a single player instance.
 class PlayerPlatformWeb extends PlayerPlatformInterface {
   PlayerPlatformWeb(
@@ -17,10 +19,13 @@ class PlayerPlatformWeb extends PlayerPlatformInterface {
   ) {
     _player = BitmovinPlayerJs(
       _createContainer(),
-      config.toPlayerConfigJs(),
+      config.toPlayerConfigJs(castManager.options),
     );
 
     _playerEventHandler = PlayerWebEventHandler(_player, _onPlatformEvent);
+    castManager.castMessageHandler = (String message) {
+      _player.addMetadata('CAST', message);
+    };
   }
 
   /// Unique identifier for this player instance.
@@ -30,6 +35,8 @@ class PlayerPlatformWeb extends PlayerPlatformInterface {
   late BitmovinPlayerJs _player;
   // ignore: unused_field
   late PlayerWebEventHandler _playerEventHandler;
+  CastManagerPlatformWeb get castManager =>
+      CastManagerPlatformInterface.instance as CastManagerPlatformWeb;
 
   web.Element _createContainer() {
     final div = web.document.createElement('div') as web.HTMLDivElement

--- a/lib/src/platform/web/player_view_platform_web.dart
+++ b/lib/src/platform/web/player_view_platform_web.dart
@@ -3,7 +3,7 @@ import 'package:bitmovin_player/src/platform.dart';
 import 'package:bitmovin_player/src/platform/player_view_platform_interface.dart';
 import 'package:flutter/widgets.dart';
 
-/// An implementation of [PlayerViewPlatformInterface] for the web platform.
+/// An implementation of [PlayerViewPlatformInterface] for the Web platform.
 /// This is specific to a single player view instance.
 class PlayerViewPlatformWeb extends PlayerViewPlatformInterface {
   PlayerViewPlatformWeb(

--- a/lib/src/platform/web/player_web_event_handler.dart
+++ b/lib/src/platform/web/player_web_event_handler.dart
@@ -22,7 +22,12 @@ class PlayerWebEventHandler {
       ..on('warning', allowInterop(_onWarning))
       ..on('ready', allowInterop(_onReady))
       ..on('sourceloaded', allowInterop(_onSourceLoaded))
-      ..on('sourceunloaded', allowInterop(_onSourceUnloaded));
+      ..on('sourceunloaded', allowInterop(_onSourceUnloaded))
+      ..on('castavailable', allowInterop(_onCastAvailable))
+      ..on('caststart', allowInterop(_onCastStart))
+      ..on('caststarted', allowInterop(_onCastStarted))
+      ..on('caststopped', allowInterop(_onCastStopped))
+      ..on('castwaitingfordevice', allowInterop(_onCastWaitingForDevice));
   }
 
   final BitmovinPlayerJs _player;
@@ -114,5 +119,25 @@ class PlayerWebEventHandler {
 
   void _onSourceUnloaded(PlayerEventBaseJs event) {
     _onPlatformEvent(event.toSourceUnloadedEvent());
+  }
+
+  void _onCastAvailable(CastAvailableEventJs event) {
+    _onPlatformEvent(event.toCastAvailableEvent());
+  }
+
+  void _onCastStart(PlayerEventBaseJs event) {
+    _onPlatformEvent(event.toCastStartEvent());
+  }
+
+  void _onCastStarted(CastStartedEventJs event) {
+    _onPlatformEvent(event.toCastStartedEvent());
+  }
+
+  void _onCastStopped(PlayerEventBaseJs event) {
+    _onPlatformEvent(event.toCastStoppedEvent());
+  }
+
+  void _onCastWaitingForDevice(CastWaitingForDeviceEventJs event) {
+    _onPlatformEvent(event.toCastWaitingForDeviceEvent());
   }
 }

--- a/lib/src/player.dart
+++ b/lib/src/player.dart
@@ -119,7 +119,7 @@ class Player with PlayerEventHandler implements PlayerApi {
   Future<void> castVideo() async => _playerPlatformInterface.castVideo();
 
   @override
-  Future<void> castStop() async => _playerPlatformInterface.castStop;
+  Future<void> castStop() async => _playerPlatformInterface.castStop();
 
   @override
   Future<bool> get isAirPlayActive async =>


### PR DESCRIPTION
## Description
Adds support for Google Cast for Web.

## Changes
- Platform abstraction for cast manager
- If cast manager has been initialized with options, set them on the player config to enable casting for the player instance
- Support for cast related events
- Support for sending custom messages to cast receiver

## TODO
- [x] Extend Casting example to show also value of `isCasting` and `isCastAvailable`
    - Done in: https://github.com/bitmovin/bitmovin-player-flutter/pull/202
- [x] Optional: Refactor Casting example for simplicity
    - Done in: https://github.com/bitmovin/bitmovin-player-flutter/pull/202
- [ ] Manually test `sendMessage` for web

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
