### PR TITLE
Implement support for unload API call

### DIFF
--- a/example/lib/controls.dart
+++ b/example/lib/controls.dart
@@ -7,6 +7,7 @@ class Controls extends StatelessWidget {
     required this.onPlayPressed,
     required this.onPausePressed,
     required this.onLoadPressed,
+    required this.onUnloadPressed,
     required this.onMutePressed,
     required this.onUnmutePressed,
     required this.onSkipForwardPressed,
@@ -17,6 +18,7 @@ class Controls extends StatelessWidget {
   final ControlAction onPlayPressed;
   final ControlAction onPausePressed;
   final ControlAction onLoadPressed;
+  final ControlAction onUnloadPressed;
   final ControlAction onMutePressed;
   final ControlAction onUnmutePressed;
   final ControlAction onSkipForwardPressed;
@@ -67,16 +69,35 @@ class Controls extends StatelessWidget {
                   spacing: 8,
                   children: [
                     OutlinedButton(
-                      onPressed: onLoadPressed,
-                      child: const Text('Reload'),
-                    ),
-                    OutlinedButton(
                       onPressed: onSkipBackwardPressed,
                       child: const Text('Skip Back'),
                     ),
                     OutlinedButton(
                       onPressed: onSkipForwardPressed,
                       child: const Text('Skip Forward'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Wrap(
+                  spacing: 8,
+                  children: [
+                    OutlinedButton(
+                      onPressed: onLoadPressed,
+                      child: const Text('Reload'),
+                    ),
+                    OutlinedButton(
+                      onPressed: onUnloadPressed,
+                      child: const Text('Unload'),
                     ),
                   ],
                 ),

--- a/example/lib/pages/analytics.dart
+++ b/example/lib/pages/analytics.dart
@@ -63,6 +63,7 @@ class _PlayerAnalyticsState extends State<PlayerAnalytics> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/audio_only.dart
+++ b/example/lib/pages/audio_only.dart
@@ -50,6 +50,7 @@ class _AudioOnlyState extends State<AudioOnly> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/background_playback.dart
+++ b/example/lib/pages/background_playback.dart
@@ -68,6 +68,7 @@ class _BackgroundPlaybackState extends State<BackgroundPlayback> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/basic_playback.dart
+++ b/example/lib/pages/basic_playback.dart
@@ -55,6 +55,7 @@ class _BasicPlaybackState extends State<BasicPlayback> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/casting.dart
+++ b/example/lib/pages/casting.dart
@@ -137,6 +137,7 @@ class _CastingState extends State<Casting> {
           margin: const EdgeInsets.only(top: 5),
           child: Controls(
             onLoadPressed: () => player.loadSourceConfig(_sourceConfig),
+            onUnloadPressed: player.unload,
             onPlayPressed: player.play,
             onPausePressed: player.pause,
             onMutePressed: player.mute,

--- a/example/lib/pages/custom_html_ui.dart
+++ b/example/lib/pages/custom_html_ui.dart
@@ -60,6 +60,7 @@ class _CustomHtmlUiState extends State<CustomHtmlUi> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/drm_playback.dart
+++ b/example/lib/pages/drm_playback.dart
@@ -103,6 +103,7 @@ class _DrmPlaybackState extends State<DrmPlayback> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/example/lib/pages/event_subscription.dart
+++ b/example/lib/pages/event_subscription.dart
@@ -107,6 +107,7 @@ class _EventSubscriptionState extends State<EventSubscription> {
             margin: const EdgeInsets.only(top: 5),
             child: Controls(
               onLoadPressed: () => _player.loadSourceConfig(_sourceConfig),
+              onUnloadPressed: _player.unload,
               onPlayPressed: _player.play,
               onPausePressed: _player.pause,
               onMutePressed: _player.mute,

--- a/ios/Classes/Event+JSON.swift
+++ b/ios/Classes/Event+JSON.swift
@@ -307,6 +307,7 @@ extension SourceRemovedEvent {
 
 extension SourceLoadEvent: SourceEventType {}
 extension SourceLoadedEvent: SourceEventType {}
+extension SourceUnloadEvent: SourceEventType {}
 extension SourceUnloadedEvent: SourceEventType {}
 
 internal protocol TimedEventType: Event {

--- a/ios/Classes/FlutterPlayer.swift
+++ b/ios/Classes/FlutterPlayer.swift
@@ -93,6 +93,8 @@ private extension FlutterPlayer {
             } else {
                 throw BitmovinError.parsingError("Could not parse arguments for \(call.method)")
             }
+        case (Methods.unload, .empty):
+            player.unload()
         case (Methods.play, .empty):
             player.play()
         case (Methods.pause, .empty):
@@ -244,7 +246,7 @@ extension FlutterPlayer: PlayerListener {
     }
 
     func onSourceUnload(_ event: SourceUnloadEvent, player: Player) {
-        broadcast(name: event.name, data: event.toJsonFallback(), sink: eventSink)
+        broadcast(name: event.name, data: event.toJSON(), sink: eventSink)
     }
 
     func onSourceWarning(_ event: SourceWarningEvent, player: Player) {

--- a/ios/Classes/Methods.swift
+++ b/ios/Classes/Methods.swift
@@ -5,6 +5,7 @@ internal enum Methods {
     static let createPlayer = "createPlayer"
     static let loadWithSourceConfig = "loadWithSourceConfig"
     static let loadWithSource = "loadWithSource"
+    static let unload = "unload"
     static let play = "play"
     static let pause = "pause"
     static let mute = "mute"

--- a/lib/src/api/player/player_api.dart
+++ b/lib/src/api/player/player_api.dart
@@ -12,6 +12,10 @@ abstract class PlayerApi {
   /// the provided [SourceConfig].
   Future<void> loadSourceConfig(SourceConfig sourceConfig);
 
+  /// Unloads the currently loaded source from the player.
+  /// If no source is loaded, this is a no-op.
+  Future<void> unload();
+
   /// Starts or resumes playback.
   Future<void> play();
 

--- a/lib/src/methods.dart
+++ b/lib/src/methods.dart
@@ -3,6 +3,7 @@ class Methods {
   static const String createPlayer = 'createPlayer';
   static const String loadWithSourceConfig = 'loadWithSourceConfig';
   static const String loadWithSource = 'loadWithSource';
+  static const String unload = 'unload';
   static const String play = 'play';
   static const String pause = 'pause';
   static const String mute = 'mute';

--- a/lib/src/platform/player_platform_interface.dart
+++ b/lib/src/platform/player_platform_interface.dart
@@ -39,6 +39,12 @@ abstract class PlayerPlatformInterface extends PlatformInterface
       widevineHandler = WidevineHandler(widevineConfig);
     }
   }
+
+  @override
+  Future<void> unload() async {
+    fairplayHandler = null;
+    widevineHandler = null;
+  }
 }
 
 class _AnalyticsApi implements AnalyticsApi {

--- a/lib/src/platform/player_platform_method_channel.dart
+++ b/lib/src/platform/player_platform_method_channel.dart
@@ -210,6 +210,12 @@ class PlayerPlatformMethodChannel extends PlayerPlatformInterface {
   }
 
   @override
+  Future<void> unload() async {
+    await super.unload();
+    return _invokeMethod<void>(Methods.unload);
+  }
+
+  @override
   Future<double> get maxTimeShift async =>
       _invokeMethod<double>(Methods.maxTimeShift);
 

--- a/lib/src/player.dart
+++ b/lib/src/player.dart
@@ -44,6 +44,9 @@ class Player with PlayerEventHandler implements PlayerApi {
       _playerPlatformInterface.loadSource(source);
 
   @override
+  Future<void> unload() async => _playerPlatformInterface.unload();
+
+  @override
   Future<void> play() async => _playerPlatformInterface.play();
 
   @override


### PR DESCRIPTION
## Description
Implements support for `player.unload()` API call

## Changes
- Support `unload()` API call
- Support `SourceUnload` and `SourceUnloaded` events

**TODO**
- [ ]  Implement support for platform Android (API call and events)
- [ ] Implement support for unload related events for platform iOS
- [ ] Manual testing on both platform that UI state clears after unload is called

## Checklist (for PR submitters and reviewers)
- [ ] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [ ] 📢 New public API is fully documented
