### PR TITLE
Add script to automatically run (and possibly apply) pre-release checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,31 @@ Before creating a pull request, please
 - Public API that is exported via `lib/bitmovin_player.dart` has to be documented with a description that explains _what_ it does
 - Every code block that does not obviously explain itself should be commented with an explanation of _why_ and _what_ it does
 
+## Release Prep
+
+Before starting a release, run:
+
+```bash
+scripts/pre_release_checks.sh
+```
+
+If you want to refresh dependencies as part of release preparation, run:
+
+```bash
+scripts/pre_release_checks.sh --apply-upgrades
+```
+
+This script is a local preflight helper. It checks dependency status for the main package and `player_testing`, runs a `pub.dev` publish dry-run, and can refresh `example/ios/Podfile.lock` via `pod install --repo-update`.
+
+For manual analysis, run each package in its own context:
+
+```bash
+fvm flutter analyze
+cd player_testing && fvm dart analyze
+```
+
+Actual releases are still performed through the `Start Release Train` and `Finish Release Train` GitHub workflows.
+
 ## Commit message convention
 
 While this is not enforced, feel free to follow the [conventional commits specification](https://www.conventionalcommits.org/en) for commit messages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,31 +56,6 @@ Before creating a pull request, please
 - Public API that is exported via `lib/bitmovin_player.dart` has to be documented with a description that explains _what_ it does
 - Every code block that does not obviously explain itself should be commented with an explanation of _why_ and _what_ it does
 
-## Release Prep
-
-Before starting a release, run:
-
-```bash
-scripts/pre_release_checks.sh
-```
-
-If you want to refresh dependencies as part of release preparation, run:
-
-```bash
-scripts/pre_release_checks.sh --apply-upgrades
-```
-
-This script is a local preflight helper. It checks dependency status for the main package and `player_testing`, runs a `pub.dev` publish dry-run, and can refresh `example/ios/Podfile.lock` via `pod install --repo-update`.
-
-For manual analysis, run each package in its own context:
-
-```bash
-fvm flutter analyze
-cd player_testing && fvm dart analyze
-```
-
-Actual releases are still performed through the `Start Release Train` and `Finish Release Train` GitHub workflows.
-
 ## Commit message convention
 
 While this is not enforced, feel free to follow the [conventional commits specification](https://www.conventionalcommits.org/en) for commit messages:

--- a/scripts/pre_release_checks.sh
+++ b/scripts/pre_release_checks.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+APPLY_UPGRADES=0
+SKIP_POD_INSTALL=0
+FAILURES=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/pre_release_checks.sh [options]
+
+Runs pre-release checks for this package.
+
+Options:
+  --apply-upgrades  Runs dependency upgrades before pod install.
+  --skip-pod-install Skips `pod install --repo-update` in example/ios.
+  -h, --help        Show this help.
+EOF
+}
+
+run_flutter() {
+  if command -v fvm >/dev/null 2>&1; then
+    fvm flutter "$@"
+    return
+  fi
+
+  if command -v flutter >/dev/null 2>&1; then
+    flutter "$@"
+    return
+  fi
+
+  echo "error: neither 'fvm' nor 'flutter' is available in PATH"
+  return 1
+}
+
+run_dart() {
+  if command -v fvm >/dev/null 2>&1; then
+    fvm dart "$@"
+    return
+  fi
+
+  if command -v dart >/dev/null 2>&1; then
+    dart "$@"
+    return
+  fi
+
+  echo "error: neither 'fvm' nor 'dart' is available in PATH"
+  return 1
+}
+
+run_step() {
+  NAME="$1"
+  shift
+
+  echo
+  echo "==> $NAME"
+  if "$@"; then
+    echo "ok: $NAME"
+  else
+    echo "failed: $NAME"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+print_sdk_versions() {
+  ANDROID_SDK_VERSION="$(sed -n "s/.*com\\.bitmovin\\.player:player:\\([^']*\\)'.*/\\1/p" android/build.gradle | head -n 1)"
+  IOS_SDK_VERSION="$(sed -n "s/.*s\\.dependency 'BitmovinPlayer', '\\([^']*\\)'.*/\\1/p" ios/bitmovin_player.podspec | head -n 1)"
+
+  echo "Configured native Player SDK versions:"
+  echo "  Android: ${ANDROID_SDK_VERSION:-not found}"
+  echo "  iOS:     ${IOS_SDK_VERSION:-not found}"
+  echo "  Note: if either SDK version changes, add an entry to CHANGELOG.md."
+}
+
+check_sdk_changelog_sync() {
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if ! git diff --quiet -- ios/bitmovin_player.podspec android/build.gradle; then
+      if git diff --quiet -- CHANGELOG.md; then
+        echo "warning: native SDK version file changed but CHANGELOG.md is unchanged."
+        return 1
+      fi
+    fi
+  fi
+}
+
+run_outdated_checks() {
+  run_step "Check outdated dependencies (all, including dev)" run_flutter pub outdated
+  run_step \
+    "Check pub.dev dependency constraints (no dev deps, up-to-date, no overrides)" \
+    run_dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides
+  run_step "Check outdated dependencies in player_testing" check_player_testing_outdated
+}
+
+run_publish_dry_run() {
+  run_step "Check pub.dev publish dry run" run_dart pub publish --dry-run
+}
+
+run_upgrades() {
+  run_step "Upgrade root dependencies (major versions allowed)" run_flutter pub upgrade --major-versions
+  run_step "Upgrade example dependencies (major versions allowed)" upgrade_example_dependencies
+  run_step "Upgrade player_testing dependencies (major versions allowed)" upgrade_player_testing_dependencies
+}
+
+update_pods() {
+  if [ "$SKIP_POD_INSTALL" -eq 1 ]; then
+    echo
+    echo "==> Skipping pod install (requested)"
+    return
+  fi
+
+  if ! command -v pod >/dev/null 2>&1; then
+    echo
+    echo "failed: pod install --repo-update (CocoaPods not found)"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  run_step "Install iOS pods (example/ios)" install_example_pods
+}
+
+upgrade_example_dependencies() {
+  cd "$ROOT_DIR/example"
+  run_flutter pub upgrade --major-versions
+}
+
+upgrade_player_testing_dependencies() {
+  cd "$ROOT_DIR/player_testing"
+  run_dart pub upgrade --major-versions
+}
+
+check_player_testing_outdated() {
+  cd "$ROOT_DIR/player_testing"
+  run_dart pub outdated
+}
+
+install_example_pods() {
+  cd "$ROOT_DIR/example/ios"
+  pod install --repo-update
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --apply-upgrades)
+      APPLY_UPGRADES=1
+      ;;
+    --skip-pod-install)
+      SKIP_POD_INSTALL=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option '$1'"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+echo "Pre-release checks for bitmovin-player-flutter"
+print_sdk_versions
+run_step "Check SDK version changes include changelog updates" check_sdk_changelog_sync
+run_outdated_checks
+run_publish_dry_run
+
+if [ "$APPLY_UPGRADES" -eq 1 ]; then
+  run_upgrades
+  update_pods
+else
+  echo
+  echo "Skipping upgrades and pod install."
+  echo "Run with '--apply-upgrades' to execute:"
+  echo "  - flutter pub upgrade --major-versions (root + example)"
+  echo "  - dart pub upgrade --major-versions in player_testing"
+  echo "  - pod install --repo-update in example/ios"
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All checks passed."
+else
+  echo "$FAILURES step(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->


  Adds an helper script to automates the [local release preparation](https://bitmovin.atlassian.net/wiki/spaces/PLAYER/pages/1988657380/How+to+Release+the+Flutter+Player+SDK#Before-starting-a-new-release).

  The script is a preflight check for maintainers before starting the release train. It:
  - prints the configured native Bitmovin Android and iOS SDK versions
  - warns if native SDK version files changed without a corresponding `CHANGELOG.md` update
  - checks outdated dependencies for the main package and player_testing
  - runs the pub.dev publish dry-run locally
  - optionally upgrades dependencies and refreshes `example/iOS/Podfile.lock` via `pod install --repo-update`


Note: this script does not replace the existing release workflows. Actual releases still happen through the Start Release Train and Finish Release Train GitHub Actions.
