### PR TITLE
Only run pre-commit when detecting significant files are changed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,20 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-FLUTTER_BIN="./.fvm/flutter_sdk/bin/flutter"
-if [ ! -x "$FLUTTER_BIN" ]; then
-  echo "error: $FLUTTER_BIN not found. Run 'fvm use' in repo root."
-  exit 1
+STAGED=$(git diff --cached --name-only)
+
+has_dart=$(echo "$STAGED" | grep -q '\.dart$' && echo 1 || echo 0)
+has_swift=$(echo "$STAGED" | grep -q '\.swift$' && echo 1 || echo 0)
+has_kotlin=$(echo "$STAGED" | grep -qE '\.(kt|kts)$' && echo 1 || echo 0)
+
+if [ "$has_dart" = "1" ]; then
+  FLUTTER_BIN="./.fvm/flutter_sdk/bin/flutter"
+  if [ ! -x "$FLUTTER_BIN" ]; then
+    echo "error: $FLUTTER_BIN not found. Run 'fvm use' in repo root."
+    exit 1
+  fi
+  "$FLUTTER_BIN" analyze
 fi
 
-"$FLUTTER_BIN" analyze
-./scripts/lint_swift.sh
-ktlint
+if [ "$has_swift" = "1" ]; then ./scripts/lint_swift.sh; fi
+if [ "$has_kotlin" = "1" ]; then ktlint; fi


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

currently ,we're always running all the pre-commit checks, no matter which files are changed

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

- Only run pre-commit checks on staged files
- Only run siwftlint check on iOS changes
- Only run ktlint check on kotlin changes
- Only run dart check on dart changes

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes - `n/a, internal`
- [x] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
