### PR TITLE
Automatically link native SDKs' release notes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,77 +4,77 @@
 
 ### Changed
 
-- Update Bitmovin's native Android SDK version to `3.151.0+jason`
-- Update Bitmovin's native iOS SDK version to `3.112.0`
+- Update Bitmovin's native Android SDK version to [`3.151.0+jason`](https://developer.bitmovin.com/playback/docs/release-notes-android#31510)
+- Update Bitmovin's native iOS SDK version to [`3.112.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31120)
 - Update Kotlin version to `2.2.21`
 
 ## [0.25.0] - 2026-03-30
 ### Changed
-- Update Bitmovin's native Android SDK version to `3.146.0+jason`
-- Update Bitmovin's native iOS SDK version to `3.110.0`
+- Update Bitmovin's native Android SDK version to [`3.146.0+jason`](https://developer.bitmovin.com/playback/docs/release-notes-android#31460)
+- Update Bitmovin's native iOS SDK version to [`3.110.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31100)
 
 ## [0.24.0] - 2026-02-13
 ### Changed
 - Increased the Android `minSdkVersion` to 23
 - Bitmovin Player Web UI integration migrates to v4. Checkout [what's new](https://developer.bitmovin.com/playback/docs/whats-new-in-ui-v4) for details
-- Update Bitmovin's native Android Player SDK version to `3.141.0+jason`
-- Update Bitmovin's native iOS Player SDK version to `3.107.0`
+- Update Bitmovin's native Android Player SDK version to [`3.141.0+jason`](https://developer.bitmovin.com/playback/docs/release-notes-android#31410)
+- Update Bitmovin's native iOS Player SDK version to [`3.107.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31070)
 - Use latest Google Cast iOS sender SDK (4.8.4) in example app
 
 ## [0.23.0] - 2025-12-18
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.136.0`
-- Update Bitmovin's native iOS Player SDK version to `3.103.0`
+- Update Bitmovin's native Android Player SDK version to [`3.136.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31360)
+- Update Bitmovin's native iOS Player SDK version to [`3.103.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31030)
 
 ## [0.22.0] - 2025-11-28
 ### Changed
 - Remove Beta label
-- Update Bitmovin's native Android Player SDK version to `3.133.0`
-- Update Bitmovin's native iOS Player SDK version to `3.100.0`
+- Update Bitmovin's native Android Player SDK version to [`3.133.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31330)
+- Update Bitmovin's native iOS Player SDK version to [`3.100.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31000)
 
 ## [0.21.0] - 2025-10-14
 ### Added
 - Support for casting Widevine-protected streams from an iOS sender
 
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.128.0`
-- Update Bitmovin's native iOS Player SDK version to `3.97.1`
+- Update Bitmovin's native Android Player SDK version to [`3.128.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31280)
+- Update Bitmovin's native iOS Player SDK version to [`3.97.1`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3971)
 
 ### Fixed
 - Missing support for `FairplayConfig.licenseRequestHeaders` and `FairplayConfig.certificateRequestHeaders`. Those fields were not serialized to JSON and not sent through the method channel to the iOS platform side
 
 ## [0.20.0] - 2025-09-05
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.125.0`
-- Update Bitmovin's native iOS Player SDK version to `3.94.1`
+- Update Bitmovin's native Android Player SDK version to [`3.125.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31250)
+- Update Bitmovin's native iOS Player SDK version to [`3.94.1`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3941)
 - Update Kotlin version to `2.1.21`
 
 ## [0.19.0] - 2025-07-09
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.117.0`
-- Update Bitmovin's native iOS Player SDK version to `3.92.1`
+- Update Bitmovin's native Android Player SDK version to [`3.117.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31170)
+- Update Bitmovin's native iOS Player SDK version to [`3.92.1`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3921)
 
 ## [0.18.0] - 2025-06-02
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.112.0`
-- Update Bitmovin's native iOS Player SDK version to `3.89.0`
+- Update Bitmovin's native Android Player SDK version to [`3.112.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31120)
+- Update Bitmovin's native iOS Player SDK version to [`3.89.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3890)
 
 ## [0.17.0] - 2025-04-09
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.106.0`
-- Update Bitmovin's native iOS Player SDK version to `3.86.0`
+- Update Bitmovin's native Android Player SDK version to [`3.106.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31060)
+- Update Bitmovin's native iOS Player SDK version to [`3.86.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3860)
 
 ## [0.16.0] - 2025-02-20
 ### Changed
 - Replace usage of deprecated `dart:html` with new `package:web`
 - Replace usage of deprecated `package:js` with new `dart:js_interop`
-- Update Bitmovin's native Android Player SDK version to `3.103.0`
-- Update Bitmovin's native iOS Player SDK version to `3.84.0`
+- Update Bitmovin's native Android Player SDK version to [`3.103.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#31030)
+- Update Bitmovin's native iOS Player SDK version to [`3.84.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3840)
 
 ## [0.15.0] - 2025-01-21
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.100.2`
-- Update Bitmovin's native iOS Player SDK version to `3.82.0`
+- Update Bitmovin's native Android Player SDK version to [`3.100.2`](https://developer.bitmovin.com/playback/docs/release-notes-android#31002)
+- Update Bitmovin's native iOS Player SDK version to [`3.82.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3820)
 
 ## [0.14.0] - 2024-12-13
 ### Added
@@ -82,8 +82,8 @@
 - Support for `Player.isPaused` and `Player.isMuted`
 
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.99.0`
-- Update Bitmovin's native iOS Player SDK version to `3.80.0`
+- Update Bitmovin's native Android Player SDK version to [`3.99.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3990)
+- Update Bitmovin's native iOS Player SDK version to [`3.80.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3800)
 
 ## [0.13.0] - 2024-11-26
 ### Added
@@ -92,52 +92,52 @@
   - Supported events: `play`,`playing`,`paused`,`timeChanged`,`seek`,`seeked`,`timeShift`,`timeShifted`,`playbackFinished`,`error`,`muted`,`unmuted`,`warning`,`ready`,`sourceLoaded`,`sourceUnloaded`
 
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.94.0`
-- Update Bitmovin's native iOS Player SDK version to `3.78.0`
+- Update Bitmovin's native Android Player SDK version to [`3.94.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3940)
+- Update Bitmovin's native iOS Player SDK version to [`3.78.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3780)
 
 ## [0.12.0] - 2024-11-06
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.91.0`
-- Update Bitmovin's native iOS Player SDK version to `3.77.0`
+- Update Bitmovin's native Android Player SDK version to [`3.91.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3910)
+- Update Bitmovin's native iOS Player SDK version to [`3.77.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3770)
 
 ### Removed
 - Custom spec source `https://github.com/bitmovin/cocoapod-specs.git` from `example/ios/Podfile` as `BitmovinPlayer` is now published to the public CocoaPods registry
 
 ## [0.11.0] - 2024-09-11
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.82.0`
-- Update Bitmovin's native iOS Player SDK version to `3.71.0`
+- Update Bitmovin's native Android Player SDK version to [`3.82.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3820)
+- Update Bitmovin's native iOS Player SDK version to [`3.71.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3710)
 
 ## [0.10.0] - 2024-08-07
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.78.0`
-- Update Bitmovin's native iOS Player SDK version to `3.68.0`
+- Update Bitmovin's native Android Player SDK version to [`3.78.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3780)
+- Update Bitmovin's native iOS Player SDK version to [`3.68.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3680)
 
 ## [0.9.0] - 2024-07-03
 ### Changed
 - Update example app dependency: Google Cast iOS sender SDK to `4.8.1`
-- Update Bitmovin's native Android Player SDK version to `3.75.0`
-- Update Bitmovin's native iOS Player SDK version to `3.66.1`
+- Update Bitmovin's native Android Player SDK version to [`3.75.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3750)
+- Update Bitmovin's native iOS Player SDK version to [`3.66.1`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3661)
 
 ## [0.8.0] - 2024-05-13
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.68.0`
-- Update Bitmovin's native iOS Player SDK version to `3.62.0`
+- Update Bitmovin's native Android Player SDK version to [`3.68.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3680)
+- Update Bitmovin's native iOS Player SDK version to [`3.62.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3620)
 
 ## [0.7.0] - 2024-04-08
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.65.0`
-- Update Bitmovin's native iOS Player SDK version to `3.59.0`
+- Update Bitmovin's native Android Player SDK version to [`3.65.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3650)
+- Update Bitmovin's native iOS Player SDK version to [`3.59.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3590)
 
 ## [0.6.0] - 2024-03-12
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.62.0`
-- Update Bitmovin's native iOS Player SDK version to `3.57.0`
+- Update Bitmovin's native Android Player SDK version to [`3.62.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3620)
+- Update Bitmovin's native iOS Player SDK version to [`3.57.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3570)
 
 ## [0.5.0] - 2024-01-08
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.55.0`
-- Update Bitmovin's native iOS Player SDK version to `3.52.0`
+- Update Bitmovin's native Android Player SDK version to [`3.55.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3550)
+- Update Bitmovin's native iOS Player SDK version to [`3.52.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3520)
 
 ### Added
 - Support for Picture-in-Picture (PiP) playback on Android
@@ -180,8 +180,8 @@
   - `AirPlayChangedEvent` which is emitted when AirPlay playback starts or stops
 
 ### Changed
-- Update Bitmovin's native Android Player SDK version to `3.52.0`
-- Update Bitmovin's native iOS Player SDK version to `3.49.0`
+- Update Bitmovin's native Android Player SDK version to [`3.52.0`](https://developer.bitmovin.com/playback/docs/release-notes-android#3520)
+- Update Bitmovin's native iOS Player SDK version to [`3.49.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#3490)
 
 ## [0.2.0] - 2023-11-06
 ### Added

--- a/scripts/link_sdk_versions.py
+++ b/scripts/link_sdk_versions.py
@@ -9,6 +9,7 @@ section on developer.bitmovin.com.
 Usage:
   scripts/link_sdk_versions.py [--dry-run] [CHANGELOG.md]
 """
+import difflib
 import re
 import sys
 from pathlib import Path
@@ -16,8 +17,8 @@ from pathlib import Path
 IOS_URL = "https://developer.bitmovin.com/playback/docs/release-notes-ios"
 ANDROID_URL = "https://developer.bitmovin.com/playback/docs/release-notes-android"
 
-# Matches `3.X.Y` or `3.X.Y+suffix` inside backticks
-VERSION_RE = re.compile(r"`(3\.\d+\.\d+(?:\+[^`]+)?)`")
+# Matches `X.Y.Z` or `X.Y.Z+suffix` inside backticks (any major version)
+VERSION_RE = re.compile(r"`(\d+\.\d+\.\d+(?:\+[^`]+)?)`")
 
 
 def version_to_anchor(version: str) -> str:
@@ -29,19 +30,19 @@ def version_to_anchor(version: str) -> str:
 def transform_line(line: str) -> str:
     if "](https://developer.bitmovin.com" in line:
         return line  # already linked
-
-    lower = line.lower()
-    if "ios" in lower:
-        base_url = IOS_URL
-    elif "android" in lower:
-        base_url = ANDROID_URL
-    else:
+    if "bitmovin" not in line.lower():
         return line
 
     def make_link(m: re.Match) -> str:
-        version = m.group(1)
-        anchor = version_to_anchor(version)
-        return f"[`{version}`]({base_url}{anchor})"
+        prefix = line[:m.start()].lower()
+        if "ios" in prefix:
+            base_url = IOS_URL
+        elif "android" in prefix:
+            base_url = ANDROID_URL
+        else:
+            return m.group(0)
+        anchor = version_to_anchor(m.group(1))
+        return f"[`{m.group(1)}`]({base_url}{anchor})"
 
     return VERSION_RE.sub(make_link, line)
 
@@ -52,7 +53,11 @@ def main() -> None:
     args = [a for a in args if a != "--dry-run"]
 
     path = Path(args[0]) if args else Path("CHANGELOG.md")
-    content = path.read_text()
+    if not path.exists():
+        print(f"error: {path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    content = path.read_text(encoding="utf-8")
     lines = content.splitlines(keepends=True)
     new_lines = [transform_line(line) for line in lines]
     new_content = "".join(new_lines)
@@ -62,7 +67,6 @@ def main() -> None:
         return
 
     if dry_run:
-        import difflib
         diff = difflib.unified_diff(
             content.splitlines(keepends=True),
             new_content.splitlines(keepends=True),
@@ -71,7 +75,7 @@ def main() -> None:
         )
         sys.stdout.writelines(diff)
     else:
-        path.write_text(new_content)
+        path.write_text(new_content, encoding="utf-8")
         changed = sum(1 for a, b in zip(lines, new_lines) if a != b)
         print(f"Updated {path} ({changed} line(s) linked)")
 

--- a/scripts/link_sdk_versions.py
+++ b/scripts/link_sdk_versions.py
@@ -2,7 +2,7 @@
 """
 Link native SDK version references in CHANGELOG.md to Bitmovin release notes.
 
-Each changelog line mentioning "iOS" or "Android" with a version like `3.X.Y`
+Each changelog line mentioning "iOS" or "Android" with a version like `X.Y.Z`
 gets that version turned into a markdown link to the corresponding release notes
 section on developer.bitmovin.com.
 

--- a/scripts/link_sdk_versions.py
+++ b/scripts/link_sdk_versions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Link native SDK version references in CHANGELOG.md to Bitmovin release notes.
+
+Each changelog line mentioning "iOS" or "Android" with a version like `3.X.Y`
+gets that version turned into a markdown link to the corresponding release notes
+section on developer.bitmovin.com.
+
+Usage:
+  scripts/link_sdk_versions.py [--dry-run] [CHANGELOG.md]
+"""
+import re
+import sys
+from pathlib import Path
+
+IOS_URL = "https://developer.bitmovin.com/playback/docs/release-notes-ios"
+ANDROID_URL = "https://developer.bitmovin.com/playback/docs/release-notes-android"
+
+# Matches `3.X.Y` or `3.X.Y+suffix` inside backticks
+VERSION_RE = re.compile(r"`(3\.\d+\.\d+(?:\+[^`]+)?)`")
+
+
+def version_to_anchor(version: str) -> str:
+    """'3.112.0' or '3.151.0+jason' -> '#31120' / '#31510'"""
+    semver = version.split("+")[0]
+    return "#" + semver.replace(".", "")
+
+
+def transform_line(line: str) -> str:
+    if "](https://developer.bitmovin.com" in line:
+        return line  # already linked
+
+    lower = line.lower()
+    if "ios" in lower:
+        base_url = IOS_URL
+    elif "android" in lower:
+        base_url = ANDROID_URL
+    else:
+        return line
+
+    def make_link(m: re.Match) -> str:
+        version = m.group(1)
+        anchor = version_to_anchor(version)
+        return f"[`{version}`]({base_url}{anchor})"
+
+    return VERSION_RE.sub(make_link, line)
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    dry_run = "--dry-run" in args
+    args = [a for a in args if a != "--dry-run"]
+
+    path = Path(args[0]) if args else Path("CHANGELOG.md")
+    content = path.read_text()
+    lines = content.splitlines(keepends=True)
+    new_lines = [transform_line(line) for line in lines]
+    new_content = "".join(new_lines)
+
+    if new_content == content:
+        print(f"No changes needed in {path}")
+        return
+
+    if dry_run:
+        import difflib
+        diff = difflib.unified_diff(
+            content.splitlines(keepends=True),
+            new_content.splitlines(keepends=True),
+            fromfile=str(path),
+            tofile=str(path) + " (linked)",
+        )
+        sys.stdout.writelines(diff)
+    else:
+        path.write_text(new_content)
+        changed = sum(1 for a, b in zip(lines, new_lines) if a != b)
+        print(f"Updated {path} ({changed} line(s) linked)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pre_release_checks.sh
+++ b/scripts/pre_release_checks.sh
@@ -164,6 +164,7 @@ done
 
 echo "Pre-release checks for bitmovin-player-flutter"
 print_sdk_versions
+run_step "Link native SDK versions in CHANGELOG.md" python3 "$ROOT_DIR/scripts/link_sdk_versions.py"
 run_step "Check SDK version changes include changelog updates" check_sdk_changelog_sync
 run_outdated_checks
 run_publish_dry_run


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

The Flutter wrapper changelog lists native SDK version bumps but gives no way to see what actually changed in those versions, readers had to manually look up the Bitmovin release notes pages.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

  - `scripts/link_sdk_versions.py` to transform `3.X.Y` / `3.X.Y+jason` version references from changelog lines into markdown links pointing to the correct section on the Bitmovin iOS/Android release notes pages.
    - Idempotent: skips already-linked lines
    - backticks are needed to detect the native SDK versions! E.g. "1.2.3" is not detected, but "\`1.2.3\`" is!
  - `scripts/pre_release_checks.sh` updated to run the linker automatically so every future release gets linked without a manual step
  - `CHANGELOG.md` update to have all 46 historical SDK version entries retroactively linked



##  How to test manually

First, add a new entry mentioning a version in backticks, e.g.:
```
- Bitmovin ios sdk version `3.112.0`
```

Then:

```shell
  # Preview what would change without touching the file
  python3 scripts/link_sdk_versions.py --dry-run

  # Apply and spot-check a few links
  python3 scripts/link_sdk_versions.py
  # Open one of the generated links in a browser, e.g.:
  # https://developer.bitmovin.com/playback/docs/release-notes-ios#31120
```

## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes - `n/a, internal tooling. But updated the SDKs references`
- [x] 🧪 Tests added and/or updated - `preferred not to setup python testing environment just for one script`
