### PR TITLE
Fix Android source event serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Avoid serializing native Android SDK source internals in source events.
+
 ## [0.26.0] - 2026-05-04
 
 ### Changed

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/EventListener.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/EventListener.kt
@@ -5,6 +5,7 @@ import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.flutter.json.JSubtitleTrack
+import com.bitmovin.player.flutter.json.sourceEventMap
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.flutter.plugin.common.EventChannel
@@ -57,10 +58,20 @@ open class EventListener {
                 broadcast("onSourceError", target)
             }
             on(SourceEvent.Load::class) {
-                broadcast("onSourceLoad", it)
+                val target =
+                    mapOf<String, Any?>(
+                        "source" to sourceEventMap(it.source),
+                        "timestamp" to it.timestamp,
+                    )
+                broadcast("onSourceLoad", target)
             }
             on(SourceEvent.Loaded::class) {
-                broadcast("onSourceLoaded", it)
+                val target =
+                    mapOf<String, Any?>(
+                        "source" to sourceEventMap(it.source),
+                        "timestamp" to it.timestamp,
+                    )
+                broadcast("onSourceLoaded", target)
             }
             on(SourceEvent.Unloaded::class) {
                 broadcast("onSourceUnloaded", it)
@@ -73,10 +84,22 @@ open class EventListener {
                 broadcast("onPlaybackFinished", it)
             }
             on(PlayerEvent.SourceAdded::class) {
-                broadcast("onSourceAdded", it)
+                val target =
+                    mapOf<String, Any?>(
+                        "source" to sourceEventMap(it.source),
+                        "index" to it.index,
+                        "timestamp" to it.timestamp,
+                    )
+                broadcast("onSourceAdded", target)
             }
             on(PlayerEvent.SourceRemoved::class) {
-                broadcast("onSourceRemoved", it)
+                val target =
+                    mapOf<String, Any?>(
+                        "source" to sourceEventMap(it.source),
+                        "index" to it.index,
+                        "timestamp" to it.timestamp,
+                    )
+                broadcast("onSourceRemoved", target)
             }
             on(PlayerEvent.TimeChanged::class) {
                 broadcast("onTimeChanged", it)

--- a/android/src/main/kotlin/com/bitmovin/player/flutter/json/JsonObjects.kt
+++ b/android/src/main/kotlin/com/bitmovin/player/flutter/json/JsonObjects.kt
@@ -5,6 +5,7 @@ import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.SeekMode
 import com.bitmovin.player.api.media.MediaFilter
 import com.bitmovin.player.api.media.subtitle.SubtitleTrack
+import com.bitmovin.player.api.source.Source
 import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.api.source.TimelineReferencePoint
 import com.bitmovin.player.api.ui.ScalingMode
@@ -29,6 +30,11 @@ internal class JSource(
 ) : JStruct {
     val sourceConfig by structGetter(::JSourceConfig).require()
 }
+
+internal fun sourceEventMap(source: Source): Map<String, Any?> =
+    mapOf(
+        "sourceConfig" to source.config,
+    )
 
 internal class JSourceConfig(
     override var map: Map<*, *>,


### PR DESCRIPTION
## Description
Fixes an Android runtime crash exposed by native Android Player SDK `3.160.0+jason` when source-related events are emitted.

The crash was caused by serializing full native SDK `Source` objects with Jackson. In newer Android SDK versions, SDK-internal source/event-emitter fields are publicly visible to Jackson, which makes serialization walk into Kotlin reflection internals and fail with `ClassNotFoundException: org.jetbrains.kotlin.name.ClassId`.

## Changes
- Serialize source-related Android events through explicit safe maps instead of full native SDK event/source objects.
- Wrap only the unsafe native `Source` object


## Checklist (for PR submitters and reviewers)
- [x] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
