### PR TITLE
Remove deprecated EquatableMixin usage

### DIFF
--- a/lib/src/api/event/player/airplay_available_event.dart
+++ b/lib/src/api/event/player/airplay_available_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'airplay_available_event.g.dart';
 
 /// Emitted when AirPlay is available.
 @JsonSerializable(explicitToJson: true)
-class AirPlayAvailableEvent extends Event with EquatableMixin {
+class AirPlayAvailableEvent extends Event {
   const AirPlayAvailableEvent({required super.timestamp});
 
   factory AirPlayAvailableEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/airplay_changed_event.dart
+++ b/lib/src/api/event/player/airplay_changed_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'airplay_changed_event.g.dart';
 
 /// Emitted when AirPlay playback starts or stops.
 @JsonSerializable(explicitToJson: true)
-class AirPlayChangedEvent extends Event with EquatableMixin {
+class AirPlayChangedEvent extends Event {
   const AirPlayChangedEvent({
     required super.timestamp,
     required this.isAirPlayActive,

--- a/lib/src/api/event/player/cast_available_event.dart
+++ b/lib/src/api/event/player/cast_available_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_available_event.g.dart';
 
 /// Emitted when casting to a cast-compatible device is available.
 @JsonSerializable(explicitToJson: true)
-class CastAvailableEvent extends Event with EquatableMixin {
+class CastAvailableEvent extends Event {
   const CastAvailableEvent({required super.timestamp});
 
   factory CastAvailableEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/cast_start_event.dart
+++ b/lib/src/api/event/player/cast_start_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_start_event.g.dart';
@@ -7,7 +6,7 @@ part 'cast_start_event.g.dart';
 /// Emitted when casting is initiated, but the user still needs to choose which
 /// device should be used.
 @JsonSerializable(explicitToJson: true)
-class CastStartEvent extends Event with EquatableMixin {
+class CastStartEvent extends Event {
   const CastStartEvent({required super.timestamp});
 
   factory CastStartEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/cast_started_event.dart
+++ b/lib/src/api/event/player/cast_started_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_started_event.g.dart';
 
 /// Emitted when the cast app is launched successfully.
 @JsonSerializable(explicitToJson: true)
-class CastStartedEvent extends Event with EquatableMixin {
+class CastStartedEvent extends Event {
   const CastStartedEvent({
     required super.timestamp,
     this.deviceName,

--- a/lib/src/api/event/player/cast_stopped_event.dart
+++ b/lib/src/api/event/player/cast_stopped_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_stopped_event.g.dart';
 
 /// Emitted when casting to a cast-compatible device is stopped.
 @JsonSerializable(explicitToJson: true)
-class CastStoppedEvent extends Event with EquatableMixin {
+class CastStoppedEvent extends Event {
   const CastStoppedEvent({required super.timestamp});
 
   factory CastStoppedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/cast_time_updated_event.dart
+++ b/lib/src/api/event/player/cast_time_updated_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_time_updated_event.g.dart';
@@ -7,7 +6,7 @@ part 'cast_time_updated_event.g.dart';
 /// Emitted when the time update from the currently used
 /// cast-compatible device is received.
 @JsonSerializable(explicitToJson: true)
-class CastTimeUpdatedEvent extends Event with EquatableMixin {
+class CastTimeUpdatedEvent extends Event {
   const CastTimeUpdatedEvent({required super.timestamp});
 
   factory CastTimeUpdatedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/cast_waiting_for_device_event.dart
+++ b/lib/src/api/event/player/cast_waiting_for_device_event.dart
@@ -1,6 +1,5 @@
 import 'package:bitmovin_player/src/api/event/data/cast_payload.dart';
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cast_waiting_for_device_event.g.dart';
@@ -8,7 +7,7 @@ part 'cast_waiting_for_device_event.g.dart';
 /// Emitted when a cast-compatible device has been chosen and the player is
 /// waiting for the device to get ready for playback.
 @JsonSerializable(explicitToJson: true)
-class CastWaitingForDeviceEvent extends Event with EquatableMixin {
+class CastWaitingForDeviceEvent extends Event {
   const CastWaitingForDeviceEvent({
     required this.castPayload,
     required super.timestamp,

--- a/lib/src/api/event/player/cue_enter_event.dart
+++ b/lib/src/api/event/player/cue_enter_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cue_enter_event.g.dart';
 
 /// Emitted when a subtitle cue transitions into the active status.
 @JsonSerializable(explicitToJson: true)
-class CueEnterEvent extends Event with EquatableMixin {
+class CueEnterEvent extends Event {
   const CueEnterEvent({
     required super.timestamp,
     required this.start,

--- a/lib/src/api/event/player/cue_exit_event.dart
+++ b/lib/src/api/event/player/cue_exit_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'cue_exit_event.g.dart';
 
 /// Emitted when a subtitle cue transitions into the inactive status.
 @JsonSerializable(explicitToJson: true)
-class CueExitEvent extends Event with EquatableMixin {
+class CueExitEvent extends Event {
   const CueExitEvent({
     required super.timestamp,
     required this.start,

--- a/lib/src/api/event/player/error_event.dart
+++ b/lib/src/api/event/player/error_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'error_event.g.dart';
@@ -7,7 +6,7 @@ part 'error_event.g.dart';
 /// The common supertype implemented by all different error events that are
 /// emitted by the [Player] or [Source].
 @JsonSerializable(explicitToJson: true)
-class ErrorEvent extends Event with EquatableMixin {
+class ErrorEvent extends Event {
   const ErrorEvent({
     required super.timestamp,
     required this.code,

--- a/lib/src/api/event/player/info_event.dart
+++ b/lib/src/api/event/player/info_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'info_event.g.dart';
@@ -7,7 +6,7 @@ part 'info_event.g.dart';
 /// The common supertype implemented by all different info events that are
 /// emitted by the [Player] or [Source].
 @JsonSerializable(explicitToJson: true)
-class InfoEvent extends Event with EquatableMixin {
+class InfoEvent extends Event {
   const InfoEvent({
     required super.timestamp,
     this.message,

--- a/lib/src/api/event/player/muted_event.dart
+++ b/lib/src/api/event/player/muted_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'muted_event.g.dart';
 
 /// Emitted when the player is muted.
 @JsonSerializable(explicitToJson: true)
-class MutedEvent extends Event with EquatableMixin {
+class MutedEvent extends Event {
   const MutedEvent({required super.timestamp});
 
   factory MutedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/paused_event.dart
+++ b/lib/src/api/event/player/paused_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'paused_event.g.dart';
 
 /// Emitted when the player is paused.
 @JsonSerializable(explicitToJson: true)
-class PausedEvent extends Event with EquatableMixin {
+class PausedEvent extends Event {
   const PausedEvent({
     required this.time,
     required super.timestamp,

--- a/lib/src/api/event/player/play_event.dart
+++ b/lib/src/api/event/player/play_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'play_event.g.dart';
 
 /// Emitted when the player receives an intention to play (i.e [Player.play]).
 @JsonSerializable(explicitToJson: true)
-class PlayEvent extends Event with EquatableMixin {
+class PlayEvent extends Event {
   const PlayEvent({
     required this.time,
     required super.timestamp,

--- a/lib/src/api/event/player/playback_finished_event.dart
+++ b/lib/src/api/event/player/playback_finished_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'playback_finished_event.g.dart';
 
 /// Emitted when playback of the [Source] has finished.
 @JsonSerializable(explicitToJson: true)
-class PlaybackFinishedEvent extends Event with EquatableMixin {
+class PlaybackFinishedEvent extends Event {
   const PlaybackFinishedEvent({super.timestamp});
 
   factory PlaybackFinishedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/playing_event.dart
+++ b/lib/src/api/event/player/playing_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'playing_event.g.dart';
@@ -7,7 +6,7 @@ part 'playing_event.g.dart';
 /// Emitted when the player enters the playing state after calling
 /// [Player.play].
 @JsonSerializable(explicitToJson: true)
-class PlayingEvent extends Event with EquatableMixin {
+class PlayingEvent extends Event {
   const PlayingEvent({
     required this.time,
     required super.timestamp,

--- a/lib/src/api/event/player/ready_event.dart
+++ b/lib/src/api/event/player/ready_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'ready_event.g.dart';
 
 /// Emitted when the player is ready to play and to handle API calls.
 @JsonSerializable(explicitToJson: true)
-class ReadyEvent extends Event with EquatableMixin {
+class ReadyEvent extends Event {
   const ReadyEvent({required super.timestamp});
 
   factory ReadyEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/seek_event.dart
+++ b/lib/src/api/event/player/seek_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/data/seek_position.dart';
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'seek_event.g.dart';
 
 /// Emitted when the player starts seeking. Only applies to VoD streams.
 @JsonSerializable(explicitToJson: true)
-class SeekEvent extends Event with EquatableMixin {
+class SeekEvent extends Event {
   const SeekEvent({
     required this.from,
     required this.to,

--- a/lib/src/api/event/player/seeked_event.dart
+++ b/lib/src/api/event/player/seeked_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'seeked_event.g.dart';
@@ -7,7 +6,7 @@ part 'seeked_event.g.dart';
 /// Emitted when seeking has finished and data is available to continue
 /// playback. Only applies to VoD streams.
 @JsonSerializable(explicitToJson: true)
-class SeekedEvent extends Event with EquatableMixin {
+class SeekedEvent extends Event {
   const SeekedEvent({
     required super.timestamp,
   });

--- a/lib/src/api/event/player/time_changed_event.dart
+++ b/lib/src/api/event/player/time_changed_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'time_changed_event.g.dart';
 
 /// Emitted when the current playback time has changed.
 @JsonSerializable(explicitToJson: true)
-class TimeChangedEvent extends Event with EquatableMixin {
+class TimeChangedEvent extends Event {
   const TimeChangedEvent({required this.time, required super.timestamp});
 
   factory TimeChangedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/time_shift_event.dart
+++ b/lib/src/api/event/player/time_shift_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'time_shift_event.g.dart';
@@ -7,7 +6,7 @@ part 'time_shift_event.g.dart';
 /// Called when the player is about to time-shift to a new position.
 /// Only applies to live streams.
 @JsonSerializable(explicitToJson: true)
-class TimeShiftEvent extends Event with EquatableMixin {
+class TimeShiftEvent extends Event {
   const TimeShiftEvent({
     required this.position,
     required this.target,

--- a/lib/src/api/event/player/time_shifted_event.dart
+++ b/lib/src/api/event/player/time_shifted_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'time_shifted_event.g.dart';
@@ -7,7 +6,7 @@ part 'time_shifted_event.g.dart';
 /// Called when time shifting has been finished and data is available to
 /// continue playback. Only applies to live streams.
 @JsonSerializable(explicitToJson: true)
-class TimeShiftedEvent extends Event with EquatableMixin {
+class TimeShiftedEvent extends Event {
   const TimeShiftedEvent({
     required super.timestamp,
   });

--- a/lib/src/api/event/player/unmuted_event.dart
+++ b/lib/src/api/event/player/unmuted_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'unmuted_event.g.dart';
 
 /// Emitted when the player is unmuted.
 @JsonSerializable(explicitToJson: true)
-class UnmutedEvent extends Event with EquatableMixin {
+class UnmutedEvent extends Event {
   const UnmutedEvent({required super.timestamp});
 
   factory UnmutedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player/warning_event.dart
+++ b/lib/src/api/event/player/warning_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'warning_event.g.dart';
@@ -7,7 +6,7 @@ part 'warning_event.g.dart';
 /// The common supertype implemented by all different warning events that are
 /// emitted by the [Player] or [Source].
 @JsonSerializable(explicitToJson: true)
-class WarningEvent extends Event with EquatableMixin {
+class WarningEvent extends Event {
   const WarningEvent({
     required super.timestamp,
     required this.code,

--- a/lib/src/api/event/player_view/fullscreen_enter_event.dart
+++ b/lib/src/api/event/player_view/fullscreen_enter_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'fullscreen_enter_event.g.dart';
 
 /// Emitted when the [PlayerView] goes into fullscreen mode.
 @JsonSerializable(explicitToJson: true)
-class FullscreenEnterEvent extends Event with EquatableMixin {
+class FullscreenEnterEvent extends Event {
   const FullscreenEnterEvent({
     required super.timestamp,
   });

--- a/lib/src/api/event/player_view/fullscreen_exit_event.dart
+++ b/lib/src/api/event/player_view/fullscreen_exit_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'fullscreen_exit_event.g.dart';
 
 /// Emitted when the [PlayerView] leaves fullscreen mode.
 @JsonSerializable(explicitToJson: true)
-class FullscreenExitEvent extends Event with EquatableMixin {
+class FullscreenExitEvent extends Event {
   const FullscreenExitEvent({
     required super.timestamp,
   });

--- a/lib/src/api/event/player_view/picture_in_picture_enter_event.dart
+++ b/lib/src/api/event/player_view/picture_in_picture_enter_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'picture_in_picture_enter_event.g.dart';
 
 /// Is called when the [PlayerView] is about to enter Picture-in-Picture mode.
 @JsonSerializable(explicitToJson: true)
-class PictureInPictureEnterEvent extends Event with EquatableMixin {
+class PictureInPictureEnterEvent extends Event {
   const PictureInPictureEnterEvent({required super.timestamp});
 
   factory PictureInPictureEnterEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player_view/picture_in_picture_entered_event.dart
+++ b/lib/src/api/event/player_view/picture_in_picture_entered_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'picture_in_picture_entered_event.g.dart';
@@ -8,7 +7,7 @@ part 'picture_in_picture_entered_event.g.dart';
 ///
 /// Only available on iOS.
 @JsonSerializable(explicitToJson: true)
-class PictureInPictureEnteredEvent extends Event with EquatableMixin {
+class PictureInPictureEnteredEvent extends Event {
   const PictureInPictureEnteredEvent({required super.timestamp});
 
   factory PictureInPictureEnteredEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player_view/picture_in_picture_exit_event.dart
+++ b/lib/src/api/event/player_view/picture_in_picture_exit_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'picture_in_picture_exit_event.g.dart';
 
 /// Is called when the [PlayerView] is about to exit Picture-In-Picture mode.
 @JsonSerializable(explicitToJson: true)
-class PictureInPictureExitEvent extends Event with EquatableMixin {
+class PictureInPictureExitEvent extends Event {
   const PictureInPictureExitEvent({required super.timestamp});
 
   factory PictureInPictureExitEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/player_view/picture_in_picture_exited_event.dart
+++ b/lib/src/api/event/player_view/picture_in_picture_exited_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'picture_in_picture_exited_event.g.dart';
@@ -8,7 +7,7 @@ part 'picture_in_picture_exited_event.g.dart';
 ///
 /// Only available on iOS.
 @JsonSerializable(explicitToJson: true)
-class PictureInPictureExitedEvent extends Event with EquatableMixin {
+class PictureInPictureExitedEvent extends Event {
   const PictureInPictureExitedEvent({required super.timestamp});
 
   factory PictureInPictureExitedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/source/source_added_event.dart
+++ b/lib/src/api/event/source/source_added_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/source.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_added_event.g.dart';
 
 /// Emitted when a [Source] was added to the player.
 @JsonSerializable(explicitToJson: true)
-class SourceAddedEvent extends Event with EquatableMixin {
+class SourceAddedEvent extends Event {
   const SourceAddedEvent({
     required this.source,
     required super.timestamp,

--- a/lib/src/api/event/source/source_error_event.dart
+++ b/lib/src/api/event/source/source_error_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_error_event.g.dart';
 
 /// Emitted when a source error occurred.
 @JsonSerializable(explicitToJson: true)
-class SourceErrorEvent extends ErrorEvent with EquatableMixin {
+class SourceErrorEvent extends ErrorEvent {
   const SourceErrorEvent({
     required super.timestamp,
     required super.code,

--- a/lib/src/api/event/source/source_info_event.dart
+++ b/lib/src/api/event/source/source_info_event.dart
@@ -1,5 +1,4 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_info_event.g.dart';
@@ -9,8 +8,8 @@ part 'source_info_event.g.dart';
 /// are subject to change. Thus, neither the timing nor the content should be
 /// used to trigger workflows, but may be used for logging.
 @JsonSerializable(explicitToJson: true)
-class SourceInfoEvent extends InfoEvent with EquatableMixin {
-  SourceInfoEvent({required super.timestamp, super.message});
+class SourceInfoEvent extends InfoEvent {
+  const SourceInfoEvent({required super.timestamp, super.message});
 
   factory SourceInfoEvent.fromJson(Map<String, dynamic> json) {
     return _$SourceInfoEventFromJson(json);

--- a/lib/src/api/event/source/source_load_event.dart
+++ b/lib/src/api/event/source/source_load_event.dart
@@ -1,14 +1,13 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/source.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_load_event.g.dart';
 
 /// Emitted when a [Source] starts loading.
 @JsonSerializable(explicitToJson: true)
-class SourceLoadEvent extends Event with EquatableMixin {
-  SourceLoadEvent({
+class SourceLoadEvent extends Event {
+  const SourceLoadEvent({
     required this.source,
     required super.timestamp,
   });

--- a/lib/src/api/event/source/source_loaded_event.dart
+++ b/lib/src/api/event/source/source_loaded_event.dart
@@ -1,6 +1,5 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/source.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_loaded_event.g.dart';
@@ -8,7 +7,7 @@ part 'source_loaded_event.g.dart';
 /// Emitted when a [Source] was loaded. This does not mean that the source is
 /// immediately ready for playback.
 @JsonSerializable(explicitToJson: true)
-class SourceLoadedEvent extends Event with EquatableMixin {
+class SourceLoadedEvent extends Event {
   const SourceLoadedEvent({
     required this.source,
     required super.timestamp,

--- a/lib/src/api/event/source/source_removed_event.dart
+++ b/lib/src/api/event/source/source_removed_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/source.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_removed_event.g.dart';
 
 /// Emitted when a [Source] was removed from the player.
 @JsonSerializable(explicitToJson: true)
-class SourceRemovedEvent extends Event with EquatableMixin {
+class SourceRemovedEvent extends Event {
   const SourceRemovedEvent({
     required this.source,
     required super.timestamp,

--- a/lib/src/api/event/source/source_unloaded_event.dart
+++ b/lib/src/api/event/source/source_unloaded_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_unloaded_event.g.dart';
 
 /// Emitted when a [Source] was unloaded.
 @JsonSerializable(explicitToJson: true)
-class SourceUnloadedEvent extends Event with EquatableMixin {
+class SourceUnloadedEvent extends Event {
   const SourceUnloadedEvent({required super.timestamp});
 
   factory SourceUnloadedEvent.fromJson(Map<String, dynamic> json) {

--- a/lib/src/api/event/source/source_warning_event.dart
+++ b/lib/src/api/event/source/source_warning_event.dart
@@ -1,12 +1,11 @@
 import 'package:bitmovin_player/bitmovin_player.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'source_warning_event.g.dart';
 
 /// Emitted when a source warning occurred.
 @JsonSerializable(explicitToJson: true)
-class SourceWarningEvent extends WarningEvent with EquatableMixin {
+class SourceWarningEvent extends WarningEvent {
   const SourceWarningEvent({
     required super.timestamp,
     required super.code,

--- a/lib/src/api/event/source/subtitle_added_event.dart
+++ b/lib/src/api/event/source/subtitle_added_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/api/media/subtitle/subtitle_track.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'subtitle_added_event.g.dart';
 
 /// Emitted when a new [SubtitleTrack] is added.
 @JsonSerializable(explicitToJson: true)
-class SubtitleAddedEvent extends Event with EquatableMixin {
+class SubtitleAddedEvent extends Event {
   const SubtitleAddedEvent({
     required this.subtitleTrack,
     required super.timestamp,

--- a/lib/src/api/event/source/subtitle_changed_event.dart
+++ b/lib/src/api/event/source/subtitle_changed_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/api/media/subtitle/subtitle_track.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'subtitle_changed_event.g.dart';
 
 /// Emitted when the selected [SubtitleTrack] is changed.
 @JsonSerializable(explicitToJson: true)
-class SubtitleChangedEvent extends Event with EquatableMixin {
+class SubtitleChangedEvent extends Event {
   const SubtitleChangedEvent({
     required super.timestamp,
     this.oldSubtitleTrack,

--- a/lib/src/api/event/source/subtitle_removed_event.dart
+++ b/lib/src/api/event/source/subtitle_removed_event.dart
@@ -1,13 +1,12 @@
 import 'package:bitmovin_player/src/api/event/event.dart';
 import 'package:bitmovin_player/src/api/media/subtitle/subtitle_track.dart';
-import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'subtitle_removed_event.g.dart';
 
 /// Emitted when a [SubtitleTrack] is removed.
 @JsonSerializable(explicitToJson: true)
-class SubtitleRemovedEvent extends Event with EquatableMixin {
+class SubtitleRemovedEvent extends Event {
   const SubtitleRemovedEvent({
     required this.subtitleTrack,
     required super.timestamp,


### PR DESCRIPTION
## Description
Fixes the analyzer failures caused by fresh dependency resolution selecting `equatable 2.1.0`, where `EquatableMixin` is deprecated.

## Changes
- Remove `with EquatableMixin` from event classes that already inherit from `Event`, `InfoEvent`, `WarningEvent`, or `ErrorEvent`.
- Mark two immutable event constructors as `const` after removing the mixin.

## Why this is safe
The affected event classes already inherit from `Event` directly or through subclasses such as `InfoEvent`, `WarningEvent`, and `ErrorEvent`.

`Event` itself extends `Equatable`, so these event classes remain `Equatable` even without `with EquatableMixin`:

```dart
class Event extends Equatable
```

`equatable 2.1.0` implements equality through the inherited `operator ==`, comparing:

```dart
other is Equatable &&
runtimeType == other.runtimeType &&
iterableEquals(props, other.props)
```

Because the affected subclasses still override `props`, the inherited `Equatable` implementation continues to use each subclass's event-specific fields for equality and hash codes.

I also verified this with a temporary Flutter test covering:

- `PlayEvent is Equatable`
- identical `PlayEvent` instances compare equal
- equal events have matching `hashCode`
- changing subclass fields such as `time` makes events unequal
- changing inherited `timestamp` makes events unequal
- runtime type still matters
- subclass-of-subclass inheritance, e.g. `SourceInfoEvent extends InfoEvent`, still uses overridden `props`

The only behavior intentionally removed is satisfying checks like `event is EquatableMixin`; equality/hash behavior is preserved through `Event extends Equatable`.

## Checklist (for PR submitters and reviewers)
- [ ] 🗒 `CHANGELOG.md` entry for new/changed features, bug fixes or important code changes
- [ ] 🧪 Tests added and/or updated
- [x] 📢 New public API is fully documented
